### PR TITLE
Add D1 bedtime story API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,42 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+interface Story {
+    id: number;
+    title: string;
+    content: string;
+    date: string;
+    image_url: string | null;
+    created: string | null;
+    updated: string | null;
+}
+
+interface Env {
+    DB: D1Database;
+}
+
 export default {
-	async fetch(request, env, ctx): Promise<Response> {
-		return new Response('Hello World!');
-	},
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+        const url = new URL(request.url);
+
+        if (request.method === 'GET' && url.pathname.startsWith('/stories/')) {
+            const [, , idStr] = url.pathname.split('/');
+            const id = Number(idStr);
+            if (!Number.isInteger(id)) {
+                return new Response('Invalid story id', { status: 400 });
+            }
+            try {
+                const stmt = env.DB.prepare('SELECT * FROM stories WHERE id = ?1').bind(id);
+                const story = await stmt.first<Story>();
+                if (!story) {
+                    return new Response('Not Found', { status: 404 });
+                }
+                return Response.json(story);
+            } catch (err) {
+                return new Response('Internal Error', { status: 500 });
+            }
+        }
+
+        return new Response('Not Found', { status: 404 });
+    },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
## Summary
- implement a `/stories/:id` API route in the worker

## Testing
- `npm test` *(fails: vitest not found)*