### PR TITLE
Add static Hello World page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello World</title>
+</head>
+<body>
+    <h1>Hello World</h1>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,16 @@ interface Story {
 
 interface Env {
     DB: D1Database;
+    ASSETS: Fetcher;
 }
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
         const url = new URL(request.url);
+
+        if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+            return env.ASSETS.fetch(request);
+        }
 
         if (request.method === 'GET' && url.pathname.startsWith('/stories/')) {
             const [, , idStr] = url.pathname.split('/');

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,18 +7,18 @@ import worker from '../src/index';
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new IncomingRequest('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+        it('responds with Hello World! (unit style)', async () => {
+                const request = new IncomingRequest('http://example.com');
+                const ctx = createExecutionContext();
+                const response = await worker.fetch(request, env, ctx);
+                await waitOnExecutionContext(ctx);
+                const body = await response.text();
+                expect(body).toContain('<h1>Hello World</h1>');
+        });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+        it('responds with Hello World! (integration style)', async () => {
+                const response = await SELF.fetch('https://example.com');
+                const body = await response.text();
+                expect(body).toContain('<h1>Hello World</h1>');
+        });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -43,7 +43,7 @@
 	 * Static Assets
 	 * https://developers.cloudflare.com/workers/static-assets/binding/
 	 */
-	// "assets": { "directory": "./public/", "binding": "ASSETS" },
+       "assets": { "directory": "./public", "binding": "ASSETS" },
 
 	/**
 	 * Service Bindings (communicate between multiple Workers)


### PR DESCRIPTION
## Summary
- configure wrangler to serve static assets
- add a `public/index.html` with a Hello World page
- handle `/` requests by serving the static asset
- update tests to check for the HTML response

## Testing
- `npm test` *(fails: vitest not found)*