### PR TITLE
Create mobile friendly React story viewer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,9 +2,60 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Hello World</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Story Viewer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; }
+        .story-container { max-width: 600px; margin: 0 auto; }
+        .story-image { width: 100%; height: auto; border-radius: 8px; }
+        .title { font-size: 2em; margin-bottom: 0.5em; }
+        .date { color: #666; margin-bottom: 1em; }
+    </style>
 </head>
 <body>
-    <h1>Hello World</h1>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script>
+        const { useState, useEffect } = React;
+
+        function App() {
+            const [story, setStory] = useState(null);
+            const [loading, setLoading] = useState(true);
+            const [error, setError] = useState(null);
+
+            useEffect(() => {
+                const params = new URLSearchParams(window.location.search);
+                const id = params.get('id') || '1';
+                fetch('/stories/' + id)
+                    .then(res => {
+                        if (!res.ok) throw new Error('Failed to load');
+                        return res.json();
+                    })
+                    .then(data => {
+                        setStory(data);
+                        setLoading(false);
+                    })
+                    .catch(err => {
+                        console.error(err);
+                        setError(err);
+                        setLoading(false);
+                    });
+            }, []);
+
+            if (loading) return React.createElement('p', null, 'Loading...');
+            if (error || !story) return React.createElement('p', null, 'Story not found.');
+
+            return React.createElement('div', { className: 'story-container' }, [
+                React.createElement('h1', { className: 'title', key: 'title' }, story.title),
+                story.image_url ? React.createElement('img', { className: 'story-image', src: story.image_url, alt: story.title, key: 'image' }) : null,
+                React.createElement('p', { className: 'date', key: 'date' }, new Date(story.date).toLocaleDateString()),
+                React.createElement('div', { className: 'content', key: 'content' }, story.content)
+            ]);
+        }
+
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(React.createElement(App));
+    </script>
 </body>
 </html>

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,19 +6,19 @@ import worker from '../src/index';
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
-describe('Hello World worker', () => {
-        it('responds with Hello World! (unit style)', async () => {
+describe('Story page', () => {
+        it('serves the story viewer (unit style)', async () => {
                 const request = new IncomingRequest('http://example.com');
                 const ctx = createExecutionContext();
                 const response = await worker.fetch(request, env, ctx);
                 await waitOnExecutionContext(ctx);
                 const body = await response.text();
-                expect(body).toContain('<h1>Hello World</h1>');
+                expect(body).toContain('<div id="root"></div>');
         });
 
-        it('responds with Hello World! (integration style)', async () => {
+        it('serves the story viewer (integration style)', async () => {
                 const response = await SELF.fetch('https://example.com');
                 const body = await response.text();
-                expect(body).toContain('<h1>Hello World</h1>');
+                expect(body).toContain('<div id="root"></div>');
         });
 });


### PR DESCRIPTION
## Summary
- upgrade index page to a mobile‑friendly React app
- fetch stories from `/stories/:id` and render them
- adjust tests for the new index page

## Testing
- `npm test` *(fails: vitest not found)*