### PR TITLE
Add story submission page

### DIFF
--- a/public/submit.html
+++ b/public/submit.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Add Story</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; }
+        form { max-width: 600px; margin: 0 auto; display: flex; flex-direction: column; gap: 0.5rem; }
+        textarea { width: 100%; font-family: inherit; }
+        img { max-width: 100%; border-radius: 8px; }
+        .drop-zone { padding: 1rem; border: 2px dashed #ccc; text-align: center; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script>
+        const { useState, useRef } = React;
+        function App() {
+            const [title, setTitle] = useState('');
+            const [content, setContent] = useState('');
+            const [imageFile, setImageFile] = useState(null);
+            const [preview, setPreview] = useState(null);
+            const fileInput = useRef(null);
+
+            const handleFile = file => {
+                if (file) {
+                    setImageFile(file);
+                    setPreview(URL.createObjectURL(file));
+                }
+            };
+
+            const onPaste = e => {
+                const file = e.clipboardData.files && e.clipboardData.files[0];
+                handleFile(file);
+            };
+
+            const onDrop = e => {
+                e.preventDefault();
+                handleFile(e.dataTransfer.files[0]);
+            };
+
+            const onDragOver = e => e.preventDefault();
+
+            const submit = async e => {
+                e.preventDefault();
+                const fd = new FormData();
+                fd.append('title', title);
+                fd.append('content', content);
+                if (imageFile) fd.append('image', imageFile, imageFile.name);
+                const res = await fetch('/stories', { method: 'POST', body: fd });
+                if (res.ok) {
+                    alert('Story saved');
+                    setTitle('');
+                    setContent('');
+                    setImageFile(null);
+                    setPreview(null);
+                    if (fileInput.current) fileInput.current.value = '';
+                } else {
+                    alert('Failed to save');
+                }
+            };
+
+            return React.createElement('form', { onSubmit: submit, onPaste, onDrop, onDragOver }, [
+                React.createElement('h1', { key: 'h' }, 'Add Story'),
+                React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
+                React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
+                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
+                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
+                preview ? React.createElement('img', { key: 'p', src: preview }) : null,
+                React.createElement('button', { key: 'b', type: 'submit' }, 'Submit')
+            ]);
+        }
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(React.createElement(App));
+    </script>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,34 @@ interface Story {
 interface Env {
     DB: D1Database;
     ASSETS: Fetcher;
+    IMAGES: R2Bucket;
+}
+
+function escapeHtml(text: string): string {
+    return text.replace(/[&<>"']/g, c => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+    }[c] as string));
+}
+
+function markdownToHtml(md: string): string {
+    return md
+        .split(/\n\n+/)
+        .map(block => {
+            const line = block.trim();
+            if (line.startsWith('### ')) return `<h3>${escapeHtml(line.slice(4))}</h3>`;
+            if (line.startsWith('## ')) return `<h2>${escapeHtml(line.slice(3))}</h2>`;
+            if (line.startsWith('# ')) return `<h1>${escapeHtml(line.slice(2))}</h1>`;
+            const html = escapeHtml(line)
+                .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+                .replace(/\*(.+?)\*/g, '<em>$1</em>')
+                .replace(/\n/g, '<br/>');
+            return `<p>${html}</p>`;
+        })
+        .join('');
 }
 
 export default {
@@ -32,6 +60,11 @@ export default {
 
         if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
             return env.ASSETS.fetch(request);
+        }
+
+        if (request.method === 'GET' && (url.pathname === '/submit' || url.pathname === '/submit.html')) {
+            const assetRequest = new Request(request.url.replace(/\/submit$/, '/submit.html'), request);
+            return env.ASSETS.fetch(assetRequest);
         }
 
         if (request.method === 'GET' && url.pathname.startsWith('/stories/')) {
@@ -47,6 +80,42 @@ export default {
                     return new Response('Not Found', { status: 404 });
                 }
                 return Response.json(story);
+            } catch (err) {
+                return new Response('Internal Error', { status: 500 });
+            }
+        }
+
+        if (request.method === 'POST' && url.pathname === '/stories') {
+            if (!request.headers.get('content-type')?.includes('multipart/form-data')) {
+                return new Response('Expected multipart/form-data', { status: 400 });
+            }
+            const data = await request.formData();
+            const title = data.get('title');
+            const contentMd = data.get('content');
+            const imageFile = data.get('image');
+
+            if (typeof title !== 'string' || typeof contentMd !== 'string') {
+                return new Response('Invalid form data', { status: 400 });
+            }
+
+            const contentHtml = markdownToHtml(contentMd);
+
+            let imageKey: string | null = null;
+            if (imageFile instanceof File) {
+                const arrayBuffer = await imageFile.arrayBuffer();
+                const parts = imageFile.name.split('.');
+                const ext = parts.length > 1 ? '.' + parts.pop() : '';
+                imageKey = crypto.randomUUID() + ext;
+                await env.IMAGES.put(imageKey, arrayBuffer);
+            }
+
+            try {
+                const stmt = env.DB.prepare(
+                    'INSERT INTO stories (title, content, date, image_url, created, updated) VALUES (?1, ?2, ?3, ?4, datetime(\'now\'), datetime(\'now\'))'
+                ).bind(title, contentHtml, new Date().toISOString(), imageKey);
+                const result = await stmt.run();
+                const id = result.meta.last_row_id;
+                return Response.json({ id });
             } catch (err) {
                 return new Response('Internal Error', { status: 500 });
             }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -21,4 +21,10 @@ describe('Story page', () => {
                 const body = await response.text();
                 expect(body).toContain('<div id="root"></div>');
         });
+
+        it('serves the submit page', async () => {
+                const response = await SELF.fetch('https://example.com/submit');
+                const body = await response.text();
+                expect(body).toContain('Add Story');
+        });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,11 +23,15 @@
 	 * https://developers.cloudflare.com/workers/runtime-apis/bindings/
 	 */
 
-	"d1_databases": [{
-		"binding": "DB",
-		"database_name": "bedtime-stories",
-		"database_id": "6e61a56c-ae60-4df2-813b-0906401ecd7d"
- 	}],
+        "d1_databases": [{
+                "binding": "DB",
+                "database_name": "bedtime-stories",
+                "database_id": "6e61a56c-ae60-4df2-813b-0906401ecd7d"
+        }],
+       "r2_buckets": [{
+               "binding": "IMAGES",
+               "bucket_name": "pub-dd7bdd98b50f4f72b3e1797a4a2694aa"
+       }],
 
 	/**
 	 * Environment Variables


### PR DESCRIPTION
## Summary
- add R2 bucket binding
- allow posting new stories with Markdown and optional image
- convert Markdown to HTML on the backend
- serve a new submit page for drag/drop or paste image uploading
- test that the submit page loads

## Testing
- `npm test` *(fails: vitest not found)*