### PR TITLE
Fix manage page blank display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,13 +62,15 @@ export default {
             return env.ASSETS.fetch(request);
         }
 
-        if (request.method === 'GET' && (url.pathname === '/submit' || url.pathname === '/submit.html')) {
-            const assetRequest = new Request(request.url.replace(/\/submit$/, '/submit.html'), request);
+        if (request.method === 'GET' &&
+            (url.pathname === '/submit' || url.pathname === '/submit.html' || url.pathname === '/submit/')) {
+            const assetRequest = new Request(request.url.replace(/\/submit\/?$/, '/submit.html'), request);
             return env.ASSETS.fetch(assetRequest);
         }
 
-        if (request.method === 'GET' && (url.pathname === '/manage' || url.pathname === '/manage.html')) {
-            const assetRequest = new Request(request.url.replace(/\/manage$/, '/manage.html'), request);
+        if (request.method === 'GET' &&
+            (url.pathname === '/manage' || url.pathname === '/manage.html' || url.pathname === '/manage/')) {
+            const assetRequest = new Request(request.url.replace(/\/manage\/?$/, '/manage.html'), request);
             return env.ASSETS.fetch(assetRequest);
         }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -28,8 +28,20 @@ describe('Story page', () => {
                 expect(body).toContain('Add Story');
         });
 
+        it('serves the submit page with trailing slash', async () => {
+                const response = await SELF.fetch('https://example.com/submit/');
+                const body = await response.text();
+                expect(body).toContain('Add Story');
+        });
+
         it('serves the manage page', async () => {
                 const response = await SELF.fetch('https://example.com/manage');
+                const body = await response.text();
+                expect(body).toContain('Manage Stories');
+        });
+
+        it('serves the manage page with trailing slash', async () => {
+                const response = await SELF.fetch('https://example.com/manage/');
                 const body = await response.text();
                 expect(body).toContain('Manage Stories');
         });


### PR DESCRIPTION
## Summary
- support trailing slashes when serving `manage` and `submit` pages so assets load correctly
- add regression tests for the new behavior

## Testing
- `npm test` *(fails: vitest not found)*