### PR TITLE
Implement pagination, search and external edit page

### DIFF
--- a/public/edit.html
+++ b/public/edit.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Edit Story</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; }
+        form { max-width: 600px; margin: 0 auto; display: flex; flex-direction: column; gap: 0.5rem; }
+        textarea { width: 100%; font-family: inherit; }
+        img { max-width: 100%; border-radius: 8px; }
+        .drop-zone { padding: 1rem; border: 2px dashed #ccc; text-align: center; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script>
+        const { useState, useEffect, useRef } = React;
+        function App() {
+            const params = new URLSearchParams(window.location.search);
+            const id = params.get('id');
+            const [title, setTitle] = useState('');
+            const [content, setContent] = useState('');
+            const [imageFile, setImageFile] = useState(null);
+            const [preview, setPreview] = useState(null);
+            const fileInput = useRef(null);
+
+            useEffect(() => {
+                fetch('/stories/' + id)
+                    .then(res => res.json())
+                    .then(data => {
+                        setTitle(data.title);
+                        const div = document.createElement('div');
+                        div.innerHTML = data.content;
+                        setContent(div.innerText);
+                        setPreview(data.image_url ? 'https://pub-dd7bdd98b50f4f72b3e1797a4a2694aa.r2.dev/' + data.image_url : null);
+                    });
+            }, [id]);
+
+            const handleFile = file => {
+                if (file) {
+                    setImageFile(file);
+                    setPreview(URL.createObjectURL(file));
+                }
+            };
+
+            const onPaste = e => {
+                const file = e.clipboardData.files && e.clipboardData.files[0];
+                handleFile(file);
+            };
+
+            const onDrop = e => {
+                e.preventDefault();
+                handleFile(e.dataTransfer.files[0]);
+            };
+
+            const onDragOver = e => e.preventDefault();
+
+            const submit = async e => {
+                e.preventDefault();
+                const fd = new FormData();
+                fd.append('title', title);
+                fd.append('content', content);
+                if (imageFile) fd.append('image', imageFile, imageFile.name);
+                const res = await fetch('/stories/' + id, { method: 'PUT', body: fd });
+                if (res.ok) {
+                    alert('Story saved');
+                    window.location.href = '/manage.html';
+                } else {
+                    alert('Failed to save');
+                }
+            };
+
+            return React.createElement('form', { onSubmit: submit, onPaste, onDrop, onDragOver }, [
+                React.createElement('h1', { key: 'h' }, 'Edit Story'),
+                React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
+                React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
+                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
+                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
+                preview ? React.createElement('img', { key: 'p', src: preview }) : null,
+                React.createElement('button', { key: 'b', type: 'submit' }, 'Save')
+            ]);
+        }
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(React.createElement(App));
+    </script>
+</body>
+</html>

--- a/public/manage.html
+++ b/public/manage.html
@@ -6,12 +6,9 @@
     <title>Manage Stories</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; }
-        form { max-width: 600px; margin: 1rem auto; display: flex; flex-direction: column; gap: 0.5rem; }
-        textarea { width: 100%; font-family: inherit; }
-        img { max-width: 100%; border-radius: 8px; }
-        .drop-zone { padding: 1rem; border: 2px dashed #ccc; text-align: center; cursor: pointer; }
-        .story-list { max-width: 600px; margin: 0 auto; }
+        .story-list { max-width: 600px; margin: 1rem auto; }
         .story-item { display: flex; justify-content: space-between; margin-bottom: 0.5rem; }
+        .pagination { display: flex; justify-content: center; gap: 0.5rem; margin-top: 1rem; }
     </style>
 </head>
 <body>
@@ -19,112 +16,59 @@
     <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script>
-        const { useState, useEffect, useRef } = React;
+        const { useState, useEffect } = React;
         function App() {
             const [stories, setStories] = useState([]);
-            const [editing, setEditing] = useState(null);
-            const [title, setTitle] = useState('');
-            const [content, setContent] = useState('');
-            const [imageFile, setImageFile] = useState(null);
-            const [preview, setPreview] = useState(null);
-            const fileInput = useRef(null);
+            const [page, setPage] = useState(1);
+            const [total, setTotal] = useState(0);
+            const [q, setQ] = useState('');
 
-            const load = () => {
-                fetch('/stories/list')
+            const load = (p = page, search = q) => {
+                fetch(`/stories/list?page=${p}&q=${encodeURIComponent(search)}`)
                     .then(res => res.json())
-                    .then(data => setStories(data));
+                    .then(data => {
+                        setStories(data.stories);
+                        setTotal(data.total);
+                        setPage(p);
+                    });
             };
 
-            useEffect(load, []);
-
-            const handleFile = file => {
-                if (file) {
-                    setImageFile(file);
-                    setPreview(URL.createObjectURL(file));
-                }
-            };
-
-            const startEdit = story => {
-                setEditing(story);
-                setTitle(story.title);
-                const div = document.createElement('div');
-                div.innerHTML = story.content;
-                setContent(div.innerText);
-                setPreview(story.image_url ? 'https://pub-dd7bdd98b50f4f72b3e1797a4a2694aa.r2.dev/' + story.image_url : null);
-                if (fileInput.current) fileInput.current.value = '';
-                setImageFile(null);
-            };
-
-            const cancelEdit = () => {
-                setEditing(null);
-                setTitle('');
-                setContent('');
-                setImageFile(null);
-                setPreview(null);
-                if (fileInput.current) fileInput.current.value = '';
-            };
-
-            const onPaste = e => {
-                const file = e.clipboardData.files && e.clipboardData.files[0];
-                handleFile(file);
-            };
-
-            const onDrop = e => {
-                e.preventDefault();
-                handleFile(e.dataTransfer.files[0]);
-            };
-
-            const onDragOver = e => e.preventDefault();
-
-            const submit = async e => {
-                e.preventDefault();
-                const fd = new FormData();
-                fd.append('title', title);
-                fd.append('content', content);
-                if (imageFile) fd.append('image', imageFile, imageFile.name);
-                const url = editing ? '/stories/' + editing.id : '/stories';
-                const method = editing ? 'PUT' : 'POST';
-                const res = await fetch(url, { method, body: fd });
-                if (res.ok) {
-                    alert('Story saved');
-                    cancelEdit();
-                    load();
-                } else {
-                    alert('Failed to save');
-                }
-            };
+            useEffect(() => load(1, q), []);
 
             const remove = async id => {
-                if (!confirm('Delete this story?')) return;
+                if (!confirm('Are You Sure?')) return;
                 const res = await fetch('/stories/' + id, { method: 'DELETE' });
                 if (res.ok) {
-                    load();
+                    load(page, q);
                 } else {
                     alert('Failed to delete');
                 }
             };
 
+            const onSearch = e => {
+                const value = e.target.value;
+                setQ(value);
+                load(1, value);
+            };
+
+            const totalPages = Math.ceil(total / 10) || 1;
+
             return React.createElement(React.Fragment, null, [
+                React.createElement('h1', { key: 'h' }, 'Manage Stories'),
+                React.createElement('input', { key: 's', type: 'text', placeholder: 'Search', value: q, onChange: onSearch }),
                 React.createElement('div', { key: 'list', className: 'story-list' }, stories.map(s =>
                     React.createElement('div', { key: s.id, className: 'story-item' }, [
                         React.createElement('span', { key: 't' + s.id }, s.title),
                         React.createElement('span', { key: 'a' + s.id }, [
-                            React.createElement('button', { key: 'e', onClick: () => startEdit(s) }, 'Edit'),
+                            React.createElement('button', { key: 'e', onClick: () => window.location.href = '/edit.html?id=' + s.id }, 'Edit'),
                             React.createElement('button', { key: 'd', onClick: () => remove(s.id) }, 'Delete')
                         ])
                     ])
                 )),
-                React.createElement('form', { key: 'form', onSubmit: submit, onPaste, onDrop, onDragOver }, [
-                    React.createElement('h1', { key: 'h' }, editing ? 'Edit Story' : 'Add Story'),
-                    React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
-                    React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
-                    React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
-                    React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
-                    preview ? React.createElement('img', { key: 'p', src: preview }) : null,
-                    React.createElement('div', { key: 'buttons' }, [
-                        React.createElement('button', { key: 'submit', type: 'submit' }, editing ? 'Save' : 'Submit'),
-                        editing ? React.createElement('button', { key: 'cancel', type: 'button', onClick: cancelEdit }, 'Cancel') : null
-                    ])
+                React.createElement('div', { key: 'p', className: 'pagination' }, [
+                    React.createElement('button', { key: 'prev', disabled: page <= 1, onClick: () => load(page - 1, q) }, 'Previous'),
+                    React.createElement('span', { key: 'info' }, `Page ${page} of ${totalPages}`),
+                    React.createElement('button', { key: 'next', disabled: page >= totalPages, onClick: () => load(page + 1, q) }, 'Next')
                 ])
             ]);
         }


### PR DESCRIPTION
## Summary
- enhance `/stories/list` to accept `page` and `q` query params
- serve a new `/edit` page for editing stories
- rework manage page to include search, pagination and confirmation on delete
- add dedicated edit page

## Testing
- `npm test` *(fails: vitest not found)*