### PR TITLE
Enable story date editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The worker exposes the following endpoints:
 - `GET /stories/list` – returns all stories in JSON
 - `GET /stories` – returns the most recent story
 - `GET /stories/:id` – returns a single story
-- `POST /stories` – create a new story (multipart form data)
-- `PUT /stories/:id` – update an existing story (multipart form data)
+- `POST /stories` – create a new story (multipart form data, fields: `title`, `content`, `date`, optional `image`)
+- `PUT /stories/:id` – update an existing story (multipart form data, fields: `title`, `content`, `date`, optional `image`)
 - `DELETE /stories/:id` – remove a story
 
 ## License

--- a/public/edit.html
+++ b/public/edit.html
@@ -23,6 +23,7 @@
             const id = params.get('id');
             const [title, setTitle] = useState('');
             const [content, setContent] = useState('');
+            const [date, setDate] = useState('');
             const [imageFile, setImageFile] = useState(null);
             const [preview, setPreview] = useState(null);
             const fileInput = useRef(null);
@@ -35,6 +36,7 @@
                         const div = document.createElement('div');
                         div.innerHTML = data.content;
                         setContent(div.innerText);
+                        setDate(new Date(data.date).toISOString().substring(0, 10));
                         setPreview(data.image_url ? 'https://pub-dd7bdd98b50f4f72b3e1797a4a2694aa.r2.dev/' + data.image_url : null);
                     });
             }, [id]);
@@ -63,6 +65,7 @@
                 const fd = new FormData();
                 fd.append('title', title);
                 fd.append('content', content);
+                fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
                 const res = await fetch('/stories/' + id, { method: 'PUT', body: fd });
                 if (res.ok) {
@@ -76,6 +79,7 @@
             return React.createElement('form', { onSubmit: submit, onPaste, onDrop, onDragOver }, [
                 React.createElement('h1', { key: 'h' }, 'Edit Story'),
                 React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
+                React.createElement('input', { key: 'd', type: 'date', value: date, required: true, onChange: e => setDate(e.target.value) }),
                 React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
                 React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
                 React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),

--- a/public/submit.html
+++ b/public/submit.html
@@ -21,6 +21,7 @@
         function App() {
             const [title, setTitle] = useState('');
             const [content, setContent] = useState('');
+            const [date, setDate] = useState(new Date().toISOString().substring(0, 10));
             const [imageFile, setImageFile] = useState(null);
             const [preview, setPreview] = useState(null);
             const fileInput = useRef(null);
@@ -49,12 +50,14 @@
                 const fd = new FormData();
                 fd.append('title', title);
                 fd.append('content', content);
+                fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
                 const res = await fetch('/stories', { method: 'POST', body: fd });
                 if (res.ok) {
                     alert('Story saved');
                     setTitle('');
                     setContent('');
+                    setDate(new Date().toISOString().substring(0, 10));
                     setImageFile(null);
                     setPreview(null);
                     if (fileInput.current) fileInput.current.value = '';
@@ -66,6 +69,7 @@
             return React.createElement('form', { onSubmit: submit, onPaste, onDrop, onDragOver }, [
                 React.createElement('h1', { key: 'h' }, 'Add Story'),
                 React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
+                React.createElement('input', { key: 'd', type: 'date', value: date, required: true, onChange: e => setDate(e.target.value) }),
                 React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
                 React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
                 React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),


### PR DESCRIPTION
## Summary
- allow specifying the date when submitting or editing a story
- default new stories to today's date
- document date field in API

## Testing
- `npm test` *(fails: vitest not found)*