### PR TITLE
Implement Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ This uses the configuration defined in `wrangler.jsonc` which binds:
 
 Ensure these resources exist in your Cloudflare account before deploying.
 
+### Authentication
+
+Access to the worker is protected using Google OAuth. Define a comma
+separated list of allowed Google accounts in `wrangler.jsonc` under the
+`ALLOWED_ACCOUNTS` variable. The Google OAuth client credentials should
+be stored as secrets named `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+
+
 ## Testing
 
 Unit tests are written with [Vitest](https://vitest.dev/). Run the test suite with:

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,8 +7,12 @@ import worker from '../src/index';
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 describe('Story page', () => {
+        env.GOOGLE_CLIENT_ID = 'test';
+        env.GOOGLE_CLIENT_SECRET = 'test';
+        env.ALLOWED_ACCOUNTS = 'test@example.com';
+
         it('serves the story viewer (unit style)', async () => {
-                const request = new IncomingRequest('http://example.com');
+                const request = new IncomingRequest('http://example.com', { headers: { cookie: 'session=test-token' } });
                 const ctx = createExecutionContext();
                 const response = await worker.fetch(request, env, ctx);
                 await waitOnExecutionContext(ctx);
@@ -17,31 +21,31 @@ describe('Story page', () => {
         });
 
         it('serves the story viewer (integration style)', async () => {
-                const response = await SELF.fetch('https://example.com');
+                const response = await SELF.fetch(new Request('https://example.com', { headers: { cookie: 'session=test-token' } }));
                 const body = await response.text();
                 expect(body).toContain('<div id="root"></div>');
         });
 
         it('serves the submit page', async () => {
-                const response = await SELF.fetch('https://example.com/submit');
+                const response = await SELF.fetch(new Request('https://example.com/submit', { headers: { cookie: 'session=test-token' } }));
                 const body = await response.text();
                 expect(body).toContain('Add Story');
         });
 
         it('serves the submit page with trailing slash', async () => {
-                const response = await SELF.fetch('https://example.com/submit/');
+                const response = await SELF.fetch(new Request('https://example.com/submit/', { headers: { cookie: 'session=test-token' } }));
                 const body = await response.text();
                 expect(body).toContain('Add Story');
         });
 
         it('serves the manage page', async () => {
-                const response = await SELF.fetch('https://example.com/manage');
+                const response = await SELF.fetch(new Request('https://example.com/manage', { headers: { cookie: 'session=test-token' } }));
                 const body = await response.text();
                 expect(body).toContain('Manage Stories');
         });
 
         it('serves the manage page with trailing slash', async () => {
-                const response = await SELF.fetch('https://example.com/manage/');
+                const response = await SELF.fetch(new Request('https://example.com/manage/', { headers: { cookie: 'session=test-token' } }));
                 const body = await response.text();
                 expect(body).toContain('Manage Stories');
         });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,11 +33,14 @@
                "bucket_name": "story-images"
        }],
 
-	/**
-	 * Environment Variables
-	 * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
-	 */
-	// "vars": { "MY_VARIABLE": "production_value" },
+       /**
+        * Environment Variables
+        * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
+        */
+       "vars": {
+               // Comma separated list of emails allowed to access the site
+               "ALLOWED_ACCOUNTS": ""
+       },
 	/**
 	 * Note: Use secrets to store sensitive data.
 	 * https://developers.cloudflare.com/workers/configuration/secrets/


### PR DESCRIPTION
## Summary
- add Google OAuth helpers and login/callback handlers
- restrict all routes behind authentication
- allow configuring allowed emails via `wrangler.jsonc`
- document OAuth setup in README
- update tests to pass dummy auth token

## Testing
- `npm test` *(fails: `vitest` not found)*