### PR TITLE
Add client-side auth redirect

### DIFF
--- a/public/edit.html
+++ b/public/edit.html
@@ -18,6 +18,24 @@
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script>
         const { useState, useEffect, useRef } = React;
+
+        async function authFetch(url, options) {
+            try {
+                const res = await fetch(url, options);
+                if (res.redirected && new URL(res.url).pathname === '/login') {
+                    window.location.href = '/login';
+                    throw new Error('Redirecting to login');
+                }
+                if (res.status === 401 || res.status === 403) {
+                    window.location.href = '/login';
+                    throw new Error('Unauthorized');
+                }
+                return res;
+            } catch (err) {
+                window.location.href = '/login';
+                throw err;
+            }
+        }
         function App() {
             const params = new URLSearchParams(window.location.search);
             const id = params.get('id');
@@ -29,7 +47,7 @@
             const fileInput = useRef(null);
 
             useEffect(() => {
-                fetch('/stories/' + id)
+                authFetch('/stories/' + id)
                     .then(res => res.json())
                     .then(data => {
                         setTitle(data.title);
@@ -67,7 +85,7 @@
                 fd.append('content', content);
                 fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
-                const res = await fetch('/stories/' + id, { method: 'PUT', body: fd });
+                const res = await authFetch('/stories/' + id, { method: 'PUT', body: fd });
                 if (res.ok) {
                     alert('Story saved');
                     window.location.href = '/manage.html';

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,24 @@
     <script>
         const { useState, useEffect, useRef } = React;
 
+        async function authFetch(url, options) {
+            try {
+                const res = await fetch(url, options);
+                if (res.redirected && new URL(res.url).pathname === '/login') {
+                    window.location.href = '/login';
+                    throw new Error('Redirecting to login');
+                }
+                if (res.status === 401 || res.status === 403) {
+                    window.location.href = '/login';
+                    throw new Error('Unauthorized');
+                }
+                return res;
+            } catch (err) {
+                window.location.href = '/login';
+                throw err;
+            }
+        }
+
         function App() {
             const [story, setStory] = useState(null);
             const [loading, setLoading] = useState(true);
@@ -32,14 +50,14 @@
             const startY = useRef(null);
             const updateNeighbors = id => {
                 Promise.all([
-                    fetch("/stories/" + id + "/prev").then(res => res.ok ? res.json() : null).catch(() => null),
-                    fetch("/stories/" + id + "/next").then(res => res.ok ? res.json() : null).catch(() => null)
+                    authFetch("/stories/" + id + "/prev").then(res => res.ok ? res.json() : null).catch(() => null),
+                    authFetch("/stories/" + id + "/next").then(res => res.ok ? res.json() : null).catch(() => null)
                 ]).then(([prev, next]) => { setPrevStory(prev); setNextStory(next); });
             };
 
             const load = id => {
                 const url = id ? '/stories/' + id : '/stories';
-                return fetch(url)
+                return authFetch(url)
                     .then(res => {
                         if (!res.ok) throw new Error('Failed to load');
                         return res.json();

--- a/public/manage.html
+++ b/public/manage.html
@@ -21,6 +21,24 @@
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script>
         const { useState, useEffect } = React;
+
+        async function authFetch(url, options) {
+            try {
+                const res = await fetch(url, options);
+                if (res.redirected && new URL(res.url).pathname === '/login') {
+                    window.location.href = '/login';
+                    throw new Error('Redirecting to login');
+                }
+                if (res.status === 401 || res.status === 403) {
+                    window.location.href = '/login';
+                    throw new Error('Unauthorized');
+                }
+                return res;
+            } catch (err) {
+                window.location.href = '/login';
+                throw err;
+            }
+        }
         function App() {
             const [stories, setStories] = useState([]);
             const [page, setPage] = useState(1);
@@ -28,7 +46,7 @@
             const [q, setQ] = useState('');
 
             const load = (p = page, search = q) => {
-                fetch(`/stories/list?page=${p}&q=${encodeURIComponent(search)}`)
+                authFetch(`/stories/list?page=${p}&q=${encodeURIComponent(search)}`)
                     .then(res => res.json())
                     .then(data => {
                         setStories(data.stories);
@@ -41,7 +59,7 @@
 
             const remove = async id => {
                 if (!confirm('Are You Sure?')) return;
-                const res = await fetch('/stories/' + id, { method: 'DELETE' });
+                const res = await authFetch('/stories/' + id, { method: 'DELETE' });
                 if (res.ok) {
                     load(page, q);
                 } else {

--- a/public/submit.html
+++ b/public/submit.html
@@ -18,6 +18,24 @@
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script>
         const { useState, useRef } = React;
+
+        async function authFetch(url, options) {
+            try {
+                const res = await fetch(url, options);
+                if (res.redirected && new URL(res.url).pathname === '/login') {
+                    window.location.href = '/login';
+                    throw new Error('Redirecting to login');
+                }
+                if (res.status === 401 || res.status === 403) {
+                    window.location.href = '/login';
+                    throw new Error('Unauthorized');
+                }
+                return res;
+            } catch (err) {
+                window.location.href = '/login';
+                throw err;
+            }
+        }
         function App() {
             const [title, setTitle] = useState('');
             const [content, setContent] = useState('');
@@ -52,7 +70,7 @@
                 fd.append('content', content);
                 fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
-                const res = await fetch('/stories', { method: 'POST', body: fd });
+                const res = await authFetch('/stories', { method: 'POST', body: fd });
                 if (res.ok) {
                     alert('Story saved');
                     setTitle('');


### PR DESCRIPTION
## Summary
- add `authFetch` helper to web pages
- use the helper when making API calls so unauthenticated users are redirected

## Testing
- `npm test` *(fails: vitest not found)*