### PR TITLE
Extend session cookie lifespan

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,11 +131,12 @@ export default {
             if (!email) return new Response('Unauthorized', { status: 403 });
             const allowed = env.ALLOWED_ACCOUNTS.split(',').map(a => a.trim()).filter(Boolean);
             if (allowed.length > 0 && !allowed.includes(email)) return new Response('Forbidden', { status: 403 });
+            const tenYears = 60 * 60 * 24 * 365 * 10; // seconds
             return new Response(null, {
                 status: 302,
                 headers: {
                     'Location': '/',
-                    'Set-Cookie': `session=${idToken}; HttpOnly; Path=/`
+                    'Set-Cookie': `session=${idToken}; HttpOnly; Path=/; Max-Age=${tenYears}`
                 }
             });
         }


### PR DESCRIPTION
## Summary
- keep the session cookie alive for 10 years by specifying a `Max-Age`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: unable to fetch packages)*