### PR TITLE
Move permitted accounts to D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ CREATE TABLE stories (
 CREATE INDEX idx_stories_date ON stories (date DESC);
 CREATE INDEX idx_stories_title_content ON stories(title, content);
 CREATE INDEX idx_stories_id ON stories(id);
+
+CREATE TABLE allowed_accounts (
+  email TEXT PRIMARY KEY
+);
 ```
 
 ## Deployment
@@ -63,10 +67,11 @@ Ensure these resources exist in your Cloudflare account before deploying.
 
 ### Authentication
 
-Access to the worker is protected using Google OAuth. Define a comma
-separated list of allowed Google accounts in `wrangler.jsonc` under the
-`ALLOWED_ACCOUNTS` variable. The Google OAuth client credentials should
-be stored as secrets named `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+Access to the worker is protected using Google OAuth. Permitted accounts are
+listed in the `allowed_accounts` table of the D1 database. Add or remove rows
+from this table to manage access. If the table is empty, any account is
+permitted. The Google OAuth client credentials should be stored as secrets
+named `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
 
 
 ## API Summary

--- a/db/allowed_accounts_table.sql
+++ b/db/allowed_accounts_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE allowed_accounts (
+  email TEXT PRIMARY KEY
+);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -38,8 +38,7 @@
         * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
         */
        "vars": {
-               // Comma separated list of emails allowed to access the site               
-			   "GOOGLE_CLIENT_ID": "15975951327-bal6im6n6g6lc7st1tkolontpbfelnvj.apps.googleusercontent.com",			   
+               "GOOGLE_CLIENT_ID": "15975951327-bal6im6n6g6lc7st1tkolontpbfelnvj.apps.googleusercontent.com",
        },
 	/**
 	 * Note: Use secrets to store sensitive data.


### PR DESCRIPTION
## Summary
- add `allowed_accounts` table
- read permitted accounts from the database instead of an env var
- adjust tests with a fake D1 implementation
- document new authentication setup

## Testing
- `npm test` *(fails: vitest not found)*