### PR TITLE
Implement reader/editor roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ CREATE INDEX idx_stories_title_content ON stories(title, content);
 CREATE INDEX idx_stories_id ON stories(id);
 
 CREATE TABLE allowed_accounts (
-  email TEXT PRIMARY KEY
+  email TEXT PRIMARY KEY,
+  role  TEXT NOT NULL DEFAULT 'editor'
 );
 ```
 
@@ -70,10 +71,12 @@ Ensure these resources exist in your Cloudflare account before deploying.
 ### Authentication
 
 Access to the worker is protected using Google OAuth. Permitted accounts are
-listed in the `allowed_accounts` table of the D1 database. Add or remove rows
-from this table to manage access. If the table is empty, any account is
-permitted. The Google OAuth client credentials should be stored as secrets
-named `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+listed in the `allowed_accounts` table of the D1 database along with a `role`
+value of either `reader` or `editor`. Readers can only view stories while
+editors may add, modify or delete them. Add or remove rows from this table to
+manage access. If the table is empty, any account is permitted as an editor.
+The Google OAuth client credentials should be stored as secrets named
+`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
 
 
 ## API Summary

--- a/db/allowed_accounts_table.sql
+++ b/db/allowed_accounts_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE allowed_accounts (
-  email TEXT PRIMARY KEY
+  email TEXT PRIMARY KEY,
+  role  TEXT NOT NULL DEFAULT 'editor'
 );
 
 CREATE INDEX idx_allowed_accounts ON allowed_accounts (email);


### PR DESCRIPTION
## Summary
- add a `role` column to `allowed_accounts`
- allow only editors to access submission and story editing routes
- update authentication logic to include account role
- update README to document the new column
- expand tests for reader/editor access

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b7096db48329ab1a0a48b89f830a