### PR TITLE
Add images endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The worker exposes the following endpoints:
 - `GET /` – serves the story viewer
 - `GET /submit` – serves a form to add a new story
 - `GET /manage` – serves a page to edit or delete stories
+- `GET /images/:key` – returns an image from the `IMAGES` bucket
 - `GET /stories/list` – returns all stories in JSON
 - `GET /stories` – returns the most recent story not scheduled for the future
 - `GET /stories/:id` – returns a single story

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -77,6 +77,26 @@ function createDb(accounts: (string | Account)[], stories: Story[]) {
     } as unknown as D1Database;
 }
 
+function createImages(store: Record<string, string>) {
+    return {
+        async get(key: string) {
+            const value = store[key];
+            if (!value) return null;
+            const body = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode(value));
+                    controller.close();
+                }
+            });
+            return {
+                body,
+                writeHttpMetadata(_h: Headers) {},
+                httpEtag: 'test-etag'
+            } as unknown as R2ObjectBody;
+        }
+    } as unknown as R2Bucket;
+}
+
 // For now, you'll need to do something like this to get a correctly-typed
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
@@ -85,6 +105,7 @@ describe('Story page', () => {
         env.GOOGLE_CLIENT_ID = 'test';
         env.GOOGLE_CLIENT_SECRET = 'test';
         env.DB = createDb(['test@example.com'], []);
+        env.IMAGES = createImages({});
         env.PUBLIC_VIEW = 'false';
 
         it('signs and verifies JWTs', async () => {
@@ -179,5 +200,19 @@ describe('Story page', () => {
                 const response = await SELF.fetch(new Request('https://example.com/submit'));
                 expect(response.status).toBe(302);
                 expect(response.headers.get('Location')).toBe('/login');
+        });
+
+        it('serves images from the R2 bucket', async () => {
+                env.IMAGES = createImages({ 'foo.txt': 'hello' });
+                const jwt = await signSession('test@example.com', env);
+                const response = await SELF.fetch(new Request('https://example.com/images/foo.txt', { headers: { cookie: `session=${jwt}` } }));
+                expect(await response.text()).toBe('hello');
+        });
+
+        it('allows image access without login when PUBLIC_VIEW is true', async () => {
+                env.PUBLIC_VIEW = 'true';
+                env.IMAGES = createImages({ 'foo.txt': 'world' });
+                const response = await SELF.fetch(new Request('https://example.com/images/foo.txt'));
+                expect(await response.text()).toBe('world');
         });
 });


### PR DESCRIPTION
## Summary
- add /images route for serving images from R2
- expose images when PUBLIC_VIEW is enabled
- document new API route
- test image delivery

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5c56a708329ad16e77d82596787