### PR TITLE
Serve images locally

### DIFF
--- a/public/edit.html
+++ b/public/edit.html
@@ -55,7 +55,7 @@
                         div.innerHTML = data.content;
                         setContent(div.innerText);
                         setDate(new Date(data.date).toISOString().substring(0, 10));
-                        setPreview(data.image_url ? 'https://pub-dd7bdd98b50f4f72b3e1797a4a2694aa.r2.dev/' + data.image_url : null);
+                        setPreview(data.image_url ? '/images/' + data.image_url : null);
                     });
             }, [id]);
 

--- a/public/index.html
+++ b/public/index.html
@@ -97,7 +97,7 @@
 
             return React.createElement('div', { className: 'story-container' }, [
                 React.createElement('div', { className: 'title-wrapper', key: 'title-wrap' }, [                    React.createElement('h1', { className: 'title', key: 'title' }, story.title),                    React.createElement('div', { className: 'nav-buttons', key: 'nav' }, [                        React.createElement('button', { key: 'up', onClick: loadPrev, disabled: !prevStory }, '▲'),                        React.createElement('button', { key: 'down', onClick: loadNext, disabled: !nextStory }, '▼')                    ])                ]),
-                story.image_url ? React.createElement('img', { className: 'story-image', src: "https://pub-dd7bdd98b50f4f72b3e1797a4a2694aa.r2.dev/" + story.image_url, alt: story.title, key: 'image' }) : null,
+                story.image_url ? React.createElement('img', { className: 'story-image', src: "/images/" + story.image_url, alt: story.title, key: 'image' }) : null,
                 //React.createElement('p', { className: 'date', key: 'date' }, new Date(story.date).toLocaleDateString()),
                 React.createElement('div', {
                     className: 'content',


### PR DESCRIPTION
## Summary
- reference images from the worker's `/images/` route instead of the R2 dev URL

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d937050c83298fed68ce3a961a12