### PR TITLE
Add caching headers for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The worker exposes the following endpoints:
 - `GET /` – serves the story viewer
 - `GET /submit` – serves a form to add a new story
 - `GET /manage` – serves a page to edit or delete stories
-- `GET /images/:key` – returns an image from the `IMAGES` bucket
+- `GET /images/:key` – returns an image from the `IMAGES` bucket with long-term caching
 - `GET /stories/list` – returns all stories in JSON
 - `GET /stories` – returns the most recent story not scheduled for the future
 - `GET /stories/:id` – returns a single story

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,7 @@ const routes: Route[] = [
                 const headers = new Headers();
                 obj.writeHttpMetadata(headers);
                 headers.set('etag', obj.httpEtag);
+                headers.set('Cache-Control', 'public, max-age=31536000, immutable');
                 return new Response(obj.body, { headers });
             } catch {
                 return new Response('Internal Error', { status: 500 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -207,6 +207,7 @@ describe('Story page', () => {
                 const jwt = await signSession('test@example.com', env);
                 const response = await SELF.fetch(new Request('https://example.com/images/foo.txt', { headers: { cookie: `session=${jwt}` } }));
                 expect(await response.text()).toBe('hello');
+                expect(response.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
         });
 
         it('allows image access without login when PUBLIC_VIEW is true', async () => {
@@ -214,5 +215,6 @@ describe('Story page', () => {
                 env.IMAGES = createImages({ 'foo.txt': 'world' });
                 const response = await SELF.fetch(new Request('https://example.com/images/foo.txt'));
                 expect(await response.text()).toBe('world');
+                expect(response.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
         });
 });


### PR DESCRIPTION
## Summary
- cache R2 image responses for one year
- mention caching in README
- update tests for new Cache-Control header

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840da66873c83299f71f511b6ec89a7