### PR TITLE
Fix search icon alignment

### DIFF
--- a/public/manage.html
+++ b/public/manage.html
@@ -19,7 +19,8 @@
         .search-wrapper .icon {
             position: absolute;
             left: 0.25rem;
-            top: 0.5rem; /* Align with the text field */
+            top: 0.25rem; /* Align with the text field */
+            line-height: 1;
             pointer-events: none;
         }
         .new-story { text-align: center; margin-bottom: 1rem; }


### PR DESCRIPTION
## Summary
- ensure search icon sits inside the text box on manage page

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b052241883299fa376a848e24681