### PR TITLE
Adjust story retrieval timezone

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,5 @@
 import { AuthInfo, Env, Route, Story } from './types';
-import { markdownToHtml } from './utils';
+import { markdownToHtml, easternNowIso } from './utils';
 import { signSession, SESSION_MAXAGE } from './session';
 import { verifyGoogleToken, getAccountRole, requireAuth } from './auth';
 
@@ -170,7 +170,7 @@ const routes: Route[] = [
         pattern: /^\/stories$/,
         handler: async (_request, env) => {
             try {
-                const nowIso = new Date().toISOString();
+                const nowIso = easternNowIso();
                 const stmt = env.DB.prepare(
                     'SELECT * FROM stories WHERE date <= ?1 ORDER BY date DESC, id DESC LIMIT 1'
                 ).bind(nowIso);
@@ -197,7 +197,7 @@ const routes: Route[] = [
                 try {
                     const order = match[2] === 'next' ? 'DESC' : 'ASC';
                     const cmp = match[2] === 'next' ? '<' : '>';
-                    const nowIso = new Date().toISOString();
+                    const nowIso = easternNowIso();
                     const stmt = env.DB.prepare(
                         `SELECT * FROM stories WHERE date <= ?1 AND (` +
                         `date ${cmp} (SELECT date FROM stories WHERE id = ?2)` +

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,3 +37,14 @@ export function parseCookies(cookieHeader: string | null): Record<string, string
     }
     return cookies;
 }
+
+// Return the current time shifted to US Eastern timezone as an ISO string
+export function easternNowIso(): string {
+    const now = new Date();
+    // Get the same wall-clock time in America/New_York. Parsing the string gives
+    // us a Date object in UTC representing that local time.
+    const eastern = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+    const offset = now.getTime() - eastern.getTime();
+    // Subtracting the offset yields the timestamp aligned with Eastern time
+    return new Date(now.getTime() - offset).toISOString();
+}


### PR DESCRIPTION
## Summary
- ensure story fetching compares against Eastern time
- add helper for Eastern time calculations

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d99dc99b0832985a05463c0ead019