### PR TITLE
Add optional video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ CREATE TABLE stories (
   content   TEXT NOT NULL,
   date      DATE NOT NULL,
   image_url TEXT,
+  video_url TEXT,
   created   DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated   DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/db/stories_table.sql
+++ b/db/stories_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE stories (
   content   TEXT NOT NULL,
   date      DATE NOT NULL,
   image_url TEXT,
+  video_url TEXT,
   created   DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated   DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/public/edit.html
+++ b/public/edit.html
@@ -43,7 +43,9 @@
             const [content, setContent] = useState('');
             const [date, setDate] = useState('');
             const [imageFile, setImageFile] = useState(null);
+            const [videoFile, setVideoFile] = useState(null);
             const [preview, setPreview] = useState(null);
+            const [videoPreview, setVideoPreview] = useState(null);
             const fileInput = useRef(null);
 
             useEffect(() => {
@@ -56,13 +58,19 @@
                         setContent(div.innerText);
                         setDate(new Date(data.date).toISOString().substring(0, 10));
                         setPreview(data.image_url ? '/images/' + data.image_url : null);
+                        setVideoPreview(data.video_url ? '/images/' + data.video_url : null);
                     });
             }, [id]);
 
             const handleFile = file => {
                 if (file) {
-                    setImageFile(file);
-                    setPreview(URL.createObjectURL(file));
+                    if (file.type.startsWith('video/')) {
+                        setVideoFile(file);
+                        setVideoPreview(URL.createObjectURL(file));
+                    } else {
+                        setImageFile(file);
+                        setPreview(URL.createObjectURL(file));
+                    }
                 }
             };
 
@@ -85,6 +93,7 @@
                 fd.append('content', content);
                 fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
+                if (videoFile) fd.append('video', videoFile, videoFile.name);
                 const res = await authFetch('/stories/' + id, { method: 'PUT', body: fd });
                 if (res.ok) {
                     alert('Story saved');
@@ -99,9 +108,10 @@
                 React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
                 React.createElement('input', { key: 'd', type: 'date', value: date, required: true, onChange: e => setDate(e.target.value) }),
                 React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
-                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
-                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
+                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile || videoFile ? 'Change file' : 'Click, paste or drop image or video here'),
+                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*,video/mp4', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
                 preview ? React.createElement('img', { key: 'p', src: preview }) : null,
+                videoPreview ? React.createElement('video', { key: 'vp', src: videoPreview, controls: true, style: { maxWidth: '100%' } }) : null,
                 React.createElement('button', { key: 'b', type: 'submit' }, 'Save')
             ]);
         }

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
         .nav-buttons button { background: none; border: none; cursor: pointer; font-size: 1.5rem; line-height: 1; }
         .nav-buttons button:disabled { color: #ccc; cursor: default; }
         .date { color: #666; margin-bottom: 1em; }
+        .play-btn { position: absolute; bottom: 0.5rem; right: 0.5rem; background: rgba(0,0,0,0.6); color: #fff; border: none; border-radius: 50%; width: 2rem; height: 2rem; display: flex; align-items: center; justify-content: center; cursor: pointer; }
     </style>
 </head>
 <body>
@@ -48,6 +49,8 @@
             const [nextStory, setNextStory] = useState(null);
             const [prevStory, setPrevStory] = useState(null);
             const [imageLoaded, setImageLoaded] = useState(false);
+            const [playing, setPlaying] = useState(false);
+            const videoRef = React.useRef(null);
             const updateNeighbors = id => {
                 Promise.all([
                     authFetch("/stories/" + id + "/prev").then(res => res.ok ? res.json() : null).catch(() => null),
@@ -67,6 +70,7 @@
             const setAndPush = data => {
                 setStory(data);
                 setImageLoaded(false);
+                setPlaying(false);
                 history.replaceState(null, '', '?id=' + data.id);
                 updateNeighbors(data.id);
             };
@@ -79,6 +83,18 @@
             const loadPrev = () => {
                 if (!prevStory) return;
                 setAndPush(prevStory);
+            };
+
+            const toggleVideo = () => {
+                if (!story.video_url) return;
+                if (playing) {
+                    videoRef.current.pause();
+                    videoRef.current.currentTime = 0;
+                    setPlaying(false);
+                } else {
+                    videoRef.current.play();
+                    setPlaying(true);
+                }
             };
 
             useEffect(() => {
@@ -99,7 +115,11 @@
 
             return React.createElement('div', { className: 'story-container' }, [
                 React.createElement('div', { className: 'title-wrapper', key: 'title-wrap' }, [                    React.createElement('h1', { className: 'title', key: 'title' }, story.title),                    React.createElement('div', { className: 'nav-buttons', key: 'nav' }, [                        React.createElement('button', { key: 'up', onClick: loadPrev, disabled: !prevStory }, '▲'),                        React.createElement('button', { key: 'down', onClick: loadNext, disabled: !nextStory }, '▼')                    ])                ]),
-                story.image_url ? React.createElement('img', { className: 'story-image', src: "/images/" + story.image_url, alt: story.title, key: 'image', onLoad: () => setImageLoaded(true), style: { display: imageLoaded ? 'block' : 'none' } }) : null,
+                story.image_url ? React.createElement('div', { key: 'media', style: { position: 'relative' } }, [
+                    React.createElement('img', { className: 'story-image', src: "/images/" + story.image_url, alt: story.title, onLoad: () => setImageLoaded(true), style: { display: playing ? 'none' : (imageLoaded ? 'block' : 'none') } }),
+                    story.video_url ? React.createElement('video', { ref: videoRef, src: "/images/" + story.video_url, loop: true, preload: 'auto', style: { display: playing ? 'block' : 'none', width: '100%', borderRadius: '8px' } }) : null,
+                    story.video_url ? React.createElement('button', { className: 'play-btn', onClick: toggleVideo }, playing ? '⏸' : '▶') : null
+                ]) : null,
                 //React.createElement('p', { className: 'date', key: 'date' }, new Date(story.date).toLocaleDateString()),
                 React.createElement('div', {
                     className: 'content',

--- a/public/submit.html
+++ b/public/submit.html
@@ -41,13 +41,20 @@
             const [content, setContent] = useState('');
             const [date, setDate] = useState(new Date().toISOString().substring(0, 10));
             const [imageFile, setImageFile] = useState(null);
+            const [videoFile, setVideoFile] = useState(null);
             const [preview, setPreview] = useState(null);
+            const [videoPreview, setVideoPreview] = useState(null);
             const fileInput = useRef(null);
 
             const handleFile = file => {
                 if (file) {
-                    setImageFile(file);
-                    setPreview(URL.createObjectURL(file));
+                    if (file.type.startsWith('video/')) {
+                        setVideoFile(file);
+                        setVideoPreview(URL.createObjectURL(file));
+                    } else {
+                        setImageFile(file);
+                        setPreview(URL.createObjectURL(file));
+                    }
                 }
             };
 
@@ -70,6 +77,7 @@
                 fd.append('content', content);
                 fd.append('date', date);
                 if (imageFile) fd.append('image', imageFile, imageFile.name);
+                if (videoFile) fd.append('video', videoFile, videoFile.name);
                 const res = await authFetch('/stories', { method: 'POST', body: fd });
                 if (res.ok) {
                     alert('Story saved');
@@ -77,7 +85,9 @@
                     setContent('');
                     setDate(new Date().toISOString().substring(0, 10));
                     setImageFile(null);
+                    setVideoFile(null);
                     setPreview(null);
+                    setVideoPreview(null);
                     if (fileInput.current) fileInput.current.value = '';
                 } else {
                     alert('Failed to save');
@@ -89,9 +99,10 @@
                 React.createElement('input', { key: 't', type: 'text', placeholder: 'Title', value: title, required: true, onChange: e => setTitle(e.target.value) }),
                 React.createElement('input', { key: 'd', type: 'date', value: date, required: true, onChange: e => setDate(e.target.value) }),
                 React.createElement('textarea', { key: 'c', rows: 10, placeholder: 'Story in Markdown', value: content, required: true, onChange: e => setContent(e.target.value) }),
-                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile ? 'Change image' : 'Click, paste or drop image here'),
-                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
+                React.createElement('div', { key: 'dz', className: 'drop-zone', onClick: () => fileInput.current && fileInput.current.click() }, imageFile || videoFile ? 'Change file' : 'Click, paste or drop image or video here'),
+                React.createElement('input', { key: 'f', type: 'file', accept: 'image/*,video/mp4', style: { display: 'none' }, ref: fileInput, onChange: e => handleFile(e.target.files[0]) }),
                 preview ? React.createElement('img', { key: 'p', src: preview }) : null,
+                videoPreview ? React.createElement('video', { key: 'vp', src: videoPreview, controls: true, style: { maxWidth: '100%' } }) : null,
                 React.createElement('button', { key: 'b', type: 'submit' }, 'Submit')
             ]);
         }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -239,8 +239,7 @@ const routes: Route[] = [
             const contentMd = data.get('content');
             const dateStr = data.get('date');
             const imageFile = data.get('image');
-            const videoFile = data.get('video');
-            const videoFile = data.get('video');
+            const videoFile = data.get('video');            
             if (typeof title !== 'string' || typeof contentMd !== 'string') {
                 return new Response('Invalid form data', { status: 400 });
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface Story {
     content: string;
     date: string;
     image_url: string | null;
+    video_url: string | null;
     created: string | null;
     updated: string | null;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -8,6 +8,7 @@ interface Story {
     content: string;
     date: string;
     image_url: string | null;
+    video_url: string | null;
     created: string | null;
     updated: string | null;
 }
@@ -172,8 +173,8 @@ describe('Story page', () => {
         });
 
         it('hides future stories from default endpoint', async () => {
-                const past = { id: 1, title: 'Past', content: '', date: new Date('2020-01-01').toISOString(), image_url: null, created: null, updated: null };
-                const future = { id: 2, title: 'Future', content: '', date: new Date(Date.now() + 86400000).toISOString(), image_url: null, created: null, updated: null };
+                const past = { id: 1, title: 'Past', content: '', date: new Date('2020-01-01').toISOString(), image_url: null, video_url: null, created: null, updated: null };
+                const future = { id: 2, title: 'Future', content: '', date: new Date(Date.now() + 86400000).toISOString(), image_url: null, video_url: null, created: null, updated: null };
                 env.DB = createDb(['test@example.com'], [past, future]);
                 const jwt = await signSession('test@example.com', env);
                 const response = await SELF.fetch(new Request('https://example.com/stories', { headers: { cookie: `session=${jwt}` } }));


### PR DESCRIPTION
## Summary
- allow storing a `video_url` for each story
- upload/delete videos alongside images
- preload and toggle story videos in the viewer
- permit uploading video files from the submit/edit forms
- adjust tests for updated schema

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687051d23a548329887645ca407887df