### PR TITLE
Display manage page dates in local timezone

### DIFF
--- a/public/manage.html
+++ b/public/manage.html
@@ -51,6 +51,11 @@
                 throw err;
             }
         }
+        function toLocalDateString(isoString) {
+            const date = new Date(isoString);
+            date.setMinutes(date.getMinutes() + date.getTimezoneOffset());
+            return date.toLocaleDateString();
+        }
         function App() {
             const [stories, setStories] = useState([]);
             const [page, setPage] = useState(1);
@@ -111,7 +116,7 @@
                     React.createElement('div', { key: s.id, className: 'story-item' }, [
                         React.createElement('span', { key: 't' + s.id }, [
                             s.title,
-                            React.createElement('span', { key: 'd' + s.id, className: 'date' }, ' (' + new Date(s.date).toLocaleDateString() + ')')
+                            React.createElement('span', { key: 'd' + s.id, className: 'date' }, ' (' + toLocalDateString(s.date) + ')')
                         ]),
                         React.createElement('span', { key: 'a' + s.id }, [
                             React.createElement('button', { key: 'v', onClick: () => window.location.href = '/?id=' + s.id }, 'View'),


### PR DESCRIPTION
## Summary
- Ensure manage page displays story dates in user's local timezone

## Testing
- `npm test` *(fails: DataError: Imported HMAC key length (0) must be a non-zero value up to 7 bits less than, and no greater than, the bit length of the raw key data)*

------
https://chatgpt.com/codex/tasks/task_e_689a4071ee388329843c2459d4507148