### PR TITLE
Fix #69: use nano-banana-2 and 1K default image size

### DIFF
--- a/.codex/skills/generate-story/SKILL.md
+++ b/.codex/skills/generate-story/SKILL.md
@@ -116,12 +116,12 @@ Optional flags:
 - `--json` to print a single JSON object to stdout.
 
 ## Step 2: Generate a cover image (Replicate)
-Default model: `google/nano-banana-pro`
+Default model: `google/nano-banana-2`
 Fallback model: `black-forest-labs/flux-1.1-pro`
 
 Image requirements:
 - Landscape, 16:9.
-- 2K resolution.
+- 1K resolution.
 - Cartoon aesthetic.
 - No text, letters, or signage.
 - Only include characters relevant to the selected scene.

--- a/.codex/skills/generate-story/scripts/generate-image.py
+++ b/.codex/skills/generate-story/scripts/generate-image.py
@@ -13,7 +13,7 @@ import urllib.request
 import uuid
 
 API_BASE = "https://api.replicate.com/v1"
-DEFAULT_MODEL = "google/nano-banana-pro"
+DEFAULT_MODEL = "google/nano-banana-2"
 FALLBACK_MODEL = "black-forest-labs/flux-1.1-pro"
 DEFAULT_POLL_SECONDS = 3
 
@@ -146,7 +146,7 @@ def generate(prompt: str, image_paths: list[str], model: str) -> tuple[str, str,
             "prompt": prompt,
             "image_input": image_input,
             "aspect_ratio": "16:9",
-            "resolution": "2K",
+            "resolution": "1K",
             "output_format": "jpg",
             "safety_filter_level": "block_only_high",
         }


### PR DESCRIPTION
Fixes #69

Summary:
- Switch default Replicate image model to `google/nano-banana-2` in the generate-image script.
- Reduce default image resolution from `2K` to `1K`.
- Update generate-story skill docs to match the new defaults.

Testing:
- `python3 -m py_compile .codex/skills/generate-story/scripts/generate-image.py`