### PR TITLE
Add managed story agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The Google OAuth client credentials should be stored as secrets named
 ### Agentic Story Generation
 
 The `/manage` page can launch story-generation jobs in a preconfigured Sprite.
+Story ideas may include optional reference images selected from a file picker or
+pasted into the prompt field.
 Apply `db/story_agent_tables.sql`, keep the `bedtime-stories` Sprite updated
 with the project and `generate-story` skill, and configure these Worker secrets:
 
@@ -104,6 +106,9 @@ The runner creates a Sprite task hold while Codex is actively generating a story
 refreshes it during the run, and releases it when the job completes or fails.
 Canceling a job also asks the Sprite to terminate the runner and delete that
 task hold, making the Sprite eligible to pause when idle.
+When reference images are included, the Worker stores them in R2, the runner
+downloads them into `/tmp` on the Sprite, attaches them to Codex, and instructs
+Codex to pass each path to `generate-story` as `--ref-image`.
 
 ### Security Notes
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ CREATE TABLE allowed_accounts (
 );
 ```
 
+Agentic story generation from `/manage` also requires the tables in
+`db/story_agent_tables.sql`.
+
 ## Deployment
 
 Deploy the worker to Cloudflare with:
@@ -81,11 +84,28 @@ manage access. If the table is empty, any account is permitted as an editor.
 The Google OAuth client credentials should be stored as secrets named
 `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
 
+### Agentic Story Generation
+
+The `/manage` page can launch story-generation jobs in a preconfigured Sprite.
+Apply `db/story_agent_tables.sql`, keep the `bedtime-stories` Sprite updated
+with the project and `generate-story` skill, and configure these Worker secrets:
+
+- `SPRITES_API_TOKEN` – Sprites API token used by the Worker to start commands.
+- `STORY_AGENT_ALLOWED_EMAILS` – comma-separated editor emails allowed to run costly agent jobs.
+- `STORY_API_TOKEN` – existing story automation token used by the Sprite runner.
+
+Optional vars:
+
+- `STORY_AGENT_SPRITE_NAME` – defaults to `bedtime-stories`.
+- `STORY_AGENT_SPRITE_WORKDIR` – defaults to `/home/sprite/bedtimestories/main`.
+- `STORY_AGENT_SPRITES_API_BASE` – defaults to `https://api.sprites.dev`.
+
 ### Security Notes
 
 - If `allowed_accounts` is empty, any Google account is treated as an `editor` (intentionally retained behavior; increases risk if the database is ever cleared).
 - The admin UI currently loads React from `unpkg.com` and uses inline scripts. This is a supply-chain risk (a compromised CDN response could perform authenticated actions). Recommended hardening is to self-host dependencies and move inline scripts into local JS files, then enforce a strict CSP.
 - `GET /update-cache` requires `CACHE_REFRESH_TOKEN` (Bearer auth). Do not deploy without setting it.
+- Story-generation jobs require both an editor session and `STORY_AGENT_ALLOWED_EMAILS`; leave the allowlist unset to disable this high-cost surface.
 
 ## API Summary
 
@@ -102,6 +122,10 @@ The worker exposes the following endpoints:
 - `POST /stories` – create a new story (multipart form data, fields: `title`, `content`, `date`, optional `image`)
 - `PUT /stories/:id` – update an existing story (multipart form data, fields: `title`, `content`, `date`, optional `image`)
 - `DELETE /stories/:id` – remove a story
+- `POST /agent/jobs` – create an authenticated story-generation job
+- `GET /agent/jobs/:id/events` – replay job events as an SSE stream
+- `POST /agent/jobs/:id/messages` – queue feedback for the running job
+- `POST /agent/jobs/:id/cancel` – cancel an active story-generation job
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Optional vars:
 - `STORY_AGENT_SPRITE_WORKDIR` – defaults to `/home/sprite/bedtimestories/main`.
 - `STORY_AGENT_SPRITES_API_BASE` – defaults to `https://api.sprites.dev`.
 
+The runner creates a Sprite task hold while Codex is actively generating a story,
+refreshes it during the run, and releases it when the job completes or fails.
+Canceling a job also asks the Sprite to terminate the runner and delete that
+task hold, making the Sprite eligible to pause when idle.
+
 ### Security Notes
 
 - If `allowed_accounts` is empty, any Google account is treated as an `editor` (intentionally retained behavior; increases risk if the database is ever cleared).

--- a/db/story_agent_tables.sql
+++ b/db/story_agent_tables.sql
@@ -1,0 +1,55 @@
+CREATE TABLE story_agent_jobs (
+  id                  TEXT PRIMARY KEY,
+  requested_by        TEXT NOT NULL,
+  prompt              TEXT NOT NULL,
+  target_date         DATE,
+  status              TEXT NOT NULL DEFAULT 'queued',
+  sprite_name         TEXT NOT NULL,
+  sprite_session_id   TEXT,
+  story_id            INTEGER,
+  title               TEXT,
+  error               TEXT,
+  callback_token_hash TEXT NOT NULL,
+  created             DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated             DATETIME DEFAULT CURRENT_TIMESTAMP,
+  started             DATETIME,
+  completed           DATETIME
+);
+
+CREATE INDEX idx_story_agent_jobs_requested_by ON story_agent_jobs (requested_by, created DESC);
+CREATE INDEX idx_story_agent_jobs_status ON story_agent_jobs (status, created DESC);
+
+CREATE TABLE story_agent_refs (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id       TEXT NOT NULL,
+  r2_key       TEXT NOT NULL,
+  filename     TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  created      DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (job_id) REFERENCES story_agent_jobs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_story_agent_refs_job_id ON story_agent_refs (job_id, id);
+
+CREATE TABLE story_agent_events (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id     TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  message    TEXT NOT NULL,
+  metadata   TEXT,
+  created    DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (job_id) REFERENCES story_agent_jobs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_story_agent_events_job_id ON story_agent_events (job_id, id);
+
+CREATE TABLE story_agent_messages (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id       TEXT NOT NULL,
+  author_email TEXT NOT NULL,
+  content      TEXT NOT NULL,
+  created      DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (job_id) REFERENCES story_agent_jobs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_story_agent_messages_job_id ON story_agent_messages (job_id, id);

--- a/public/manage.html
+++ b/public/manage.html
@@ -25,6 +25,25 @@
             pointer-events: none;
         }
         .new-story { text-align: center; margin-bottom: 1rem; }
+        .agent-panel { max-width: 720px; margin: 1rem auto; border: 1px solid #ddd; border-radius: 8px; padding: 1rem; background: #fafafa; }
+        .agent-panel h2 { margin: 0 0 0.75rem; font-size: 1.15rem; }
+        .agent-form { display: grid; gap: 0.5rem; }
+        .agent-form textarea { width: 100%; box-sizing: border-box; font-family: inherit; min-height: 6rem; }
+        .agent-row { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+        .agent-row input[type="date"] { min-height: 2rem; }
+        .agent-jobs { display: grid; gap: 0.4rem; margin-top: 0.75rem; }
+        .agent-job { display: flex; justify-content: space-between; gap: 0.5rem; align-items: center; padding: 0.5rem; border: 1px solid #ddd; border-radius: 6px; background: white; }
+        .agent-job button { flex-shrink: 0; }
+        .agent-status { font-size: 0.85rem; color: #555; margin-left: 0.4rem; }
+        .agent-log { margin-top: 0.75rem; padding: 0.75rem; background: #111; color: #eee; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 0.85rem; line-height: 1.35; max-height: 18rem; overflow: auto; white-space: pre-wrap; }
+        .agent-chat { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+        .agent-chat input { flex: 1; min-width: 0; }
+        .agent-error { color: #b00020; margin-top: 0.5rem; }
+        .agent-review { display: inline-block; margin-top: 0.5rem; }
+        @media (max-width: 560px) {
+            .agent-job, .agent-chat { flex-direction: column; align-items: stretch; }
+            .agent-row button, .agent-row input { width: 100%; }
+        }
     </style>
 </head>
 <body>
@@ -51,10 +70,26 @@
                 throw err;
             }
         }
+        async function agentFetch(url, options) {
+            const res = await fetch(url, options);
+            if (res.redirected && new URL(res.url).pathname === '/login') {
+                window.location.href = '/login';
+                throw new Error('Redirecting to login');
+            }
+            if (res.status === 401) {
+                window.location.href = '/login';
+                throw new Error('Unauthorized');
+            }
+            return res;
+        }
         function toLocalDateString(isoString) {
             const date = new Date(isoString);
             date.setMinutes(date.getMinutes() + date.getTimezoneOffset());
             return date.toLocaleDateString();
+        }
+        function shortPrompt(value) {
+            if (!value) return '';
+            return value.length > 80 ? value.slice(0, 77) + '...' : value;
         }
         function App() {
             const [stories, setStories] = useState([]);
@@ -62,6 +97,16 @@
             const [total, setTotal] = useState(0);
             const [q, setQ] = useState('');
             const [date, setDate] = useState('');
+            const [agentAvailable, setAgentAvailable] = useState(true);
+            const [agentPrompt, setAgentPrompt] = useState('');
+            const [agentDate, setAgentDate] = useState('');
+            const [agentFiles, setAgentFiles] = useState([]);
+            const [agentJobs, setAgentJobs] = useState([]);
+            const [activeJob, setActiveJob] = useState(null);
+            const [agentEvents, setAgentEvents] = useState([]);
+            const [agentMessage, setAgentMessage] = useState('');
+            const [agentBusy, setAgentBusy] = useState(false);
+            const [agentError, setAgentError] = useState('');
 
             const load = (p = page, search = q, d = date) => {
                 const params = new URLSearchParams({ page: String(p) });
@@ -76,7 +121,62 @@
                     });
             };
 
+            const loadAgentJobs = async () => {
+                const res = await agentFetch('/agent/jobs');
+                if (res.status === 403 || res.status === 503) {
+                    setAgentAvailable(false);
+                    return;
+                }
+                if (!res.ok) return;
+                const data = await res.json();
+                setAgentJobs(data.jobs || []);
+                if (!activeJob && data.jobs && data.jobs.length > 0) {
+                    setActiveJob(data.jobs[0]);
+                }
+            };
+
+            const refreshAgentJob = async id => {
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(id));
+                if (!res.ok) return;
+                const data = await res.json();
+                setActiveJob(data.job);
+                setAgentJobs(jobs => jobs.map(job => job.id === data.job.id ? data.job : job));
+            };
+
             useEffect(() => load(1, q, date), []);
+            useEffect(() => { loadAgentJobs(); }, []);
+            useEffect(() => {
+                if (!activeJob) return;
+                setAgentEvents([]);
+                let lastId = 0;
+                let closed = false;
+                let source = null;
+                const connect = () => {
+                    if (closed) return;
+                    const suffix = lastId ? '?after=' + lastId : '';
+                    source = new EventSource('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/events' + suffix);
+                    const onEvent = event => {
+                        lastId = Math.max(lastId, Number(event.lastEventId || 0));
+                        let data = {};
+                        try { data = JSON.parse(event.data); } catch { data = { message: event.data }; }
+                        setAgentEvents(events => events.concat([{ id: lastId, type: event.type, message: data.message || '', metadata: data.metadata || null }]).slice(-200));
+                        if (['complete','failed','canceled','running','starting'].includes(event.type)) {
+                            refreshAgentJob(activeJob.id);
+                            loadAgentJobs();
+                        }
+                    };
+                    ['status','log','feedback','warning','error','complete','failed','canceled','running','starting'].forEach(type => source.addEventListener(type, onEvent));
+                    source.onerror = () => {
+                        if (source) source.close();
+                        if (!closed) setTimeout(connect, 2500);
+                    };
+                };
+                connect();
+                return () => {
+                    closed = true;
+                    if (source) source.close();
+                };
+            }, [activeJob && activeJob.id]);
 
             const remove = async id => {
                 if (!confirm('Are You Sure?')) return;
@@ -100,13 +200,89 @@
                 load(1, q, value);
             };
 
+            const startAgentJob = async e => {
+                e.preventDefault();
+                setAgentError('');
+                setAgentBusy(true);
+                const fd = new FormData();
+                fd.append('prompt', agentPrompt);
+                if (agentDate) fd.append('date', agentDate);
+                agentFiles.forEach(file => fd.append('ref_images', file, file.name));
+                try {
+                    const res = await agentFetch('/agent/jobs', { method: 'POST', body: fd });
+                    if (!res.ok) {
+                        setAgentError(await res.text());
+                        return;
+                    }
+                    const data = await res.json();
+                    setActiveJob(data.job);
+                    setAgentJobs(jobs => [data.job].concat(jobs.filter(job => job.id !== data.job.id)));
+                    setAgentPrompt('');
+                    setAgentDate('');
+                    setAgentFiles([]);
+                } finally {
+                    setAgentBusy(false);
+                }
+            };
+
+            const sendAgentMessage = async e => {
+                e.preventDefault();
+                if (!activeJob || !agentMessage.trim()) return;
+                const content = agentMessage.trim();
+                setAgentMessage('');
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/messages', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content })
+                });
+                if (!res.ok) setAgentError(await res.text());
+            };
+
+            const cancelAgent = async () => {
+                if (!activeJob || !confirm('Cancel this generation job?')) return;
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/cancel', { method: 'POST' });
+                if (res.ok) refreshAgentJob(activeJob.id);
+                else setAgentError(await res.text());
+            };
+
             const totalPages = Math.ceil(total / 10) || 1;
+            const agentActive = activeJob && !['complete','failed','canceled'].includes(activeJob.status);
 
             return React.createElement(React.Fragment, null, [
                 React.createElement('h1', { key: 'h' }, 'Manage Stories'),
                 React.createElement('div', { key: 'new', className: 'new-story' },
                     React.createElement('button', { onClick: () => window.location.href = '/submit' }, 'Submit New Story')
                 ),
+                agentAvailable ? React.createElement('section', { key: 'agent', className: 'agent-panel' }, [
+                    React.createElement('h2', { key: 'h' }, 'Generate with Codex'),
+                    React.createElement('form', { key: 'f', className: 'agent-form', onSubmit: startAgentJob }, [
+                        React.createElement('textarea', { key: 'p', placeholder: 'Story idea', value: agentPrompt, required: true, maxLength: 4000, onChange: e => setAgentPrompt(e.target.value) }),
+                        React.createElement('div', { key: 'r', className: 'agent-row' }, [
+                            React.createElement('input', { key: 'd', type: 'date', value: agentDate, onChange: e => setAgentDate(e.target.value) }),
+                            React.createElement('input', { key: 'i', type: 'file', accept: 'image/jpeg,image/png,image/webp', multiple: true, onChange: e => setAgentFiles(Array.from(e.target.files || []).slice(0, 3)) }),
+                            React.createElement('button', { key: 'b', type: 'submit', disabled: agentBusy || !agentPrompt.trim() }, agentBusy ? 'Starting...' : 'Start')
+                        ])
+                    ]),
+                    agentError ? React.createElement('div', { key: 'err', className: 'agent-error' }, agentError) : null,
+                    React.createElement('div', { key: 'jobs', className: 'agent-jobs' }, agentJobs.map(job =>
+                        React.createElement('div', { key: job.id, className: 'agent-job' }, [
+                            React.createElement('span', { key: 's' }, [
+                                shortPrompt(job.prompt),
+                                React.createElement('span', { key: 'st', className: 'agent-status' }, job.status)
+                            ]),
+                            React.createElement('button', { key: 'v', type: 'button', onClick: () => setActiveJob(job) }, activeJob && activeJob.id === job.id ? 'Selected' : 'Open')
+                        ])
+                    )),
+                    activeJob ? React.createElement(React.Fragment, { key: 'active' }, [
+                        React.createElement('div', { key: 'log', className: 'agent-log' }, agentEvents.length ? agentEvents.map(event => `[${event.type}] ${event.message}`).join('\n') : 'Waiting for events...'),
+                        activeJob.review_url ? React.createElement('a', { key: 'review', className: 'agent-review', href: activeJob.review_url, target: '_blank', rel: 'noopener' }, 'Review created story') : null,
+                        agentActive ? React.createElement('form', { key: 'chat', className: 'agent-chat', onSubmit: sendAgentMessage }, [
+                            React.createElement('input', { key: 'm', type: 'text', value: agentMessage, maxLength: 2000, placeholder: 'Send feedback', onChange: e => setAgentMessage(e.target.value) }),
+                            React.createElement('button', { key: 'send', type: 'submit', disabled: !agentMessage.trim() }, 'Send'),
+                            React.createElement('button', { key: 'cancel', type: 'button', onClick: cancelAgent }, 'Cancel')
+                        ]) : null
+                    ]) : null
+                ]) : null,
                 React.createElement('div', { key: 'search', className: 'search-wrapper' }, [
                     React.createElement('span', { key: 'i', className: 'icon' }, '🔍'),
                     React.createElement('input', { key: 's', type: 'text', placeholder: 'Search', value: q, onChange: onSearch }),

--- a/public/manage.html
+++ b/public/manage.html
@@ -38,6 +38,9 @@
         .agent-log { margin-top: 0.75rem; padding: 0.75rem; background: #111; color: #eee; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 0.85rem; line-height: 1.35; max-height: 18rem; overflow: auto; white-space: pre-wrap; }
         .agent-chat { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
         .agent-chat input { flex: 1; min-width: 0; }
+        .agent-files { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .agent-file { display: inline-flex; align-items: center; gap: 0.25rem; border: 1px solid #ccc; border-radius: 6px; padding: 0.2rem 0.4rem; background: white; font-size: 0.85rem; }
+        .agent-file button { border: 0; background: transparent; cursor: pointer; font-weight: bold; line-height: 1; }
         .agent-error { color: #b00020; margin-top: 0.5rem; }
         .agent-review { display: inline-block; margin-top: 0.5rem; }
         @media (max-width: 560px) {
@@ -91,6 +94,9 @@
             if (!value) return '';
             return value.length > 80 ? value.slice(0, 77) + '...' : value;
         }
+        function imageFilesFromList(list) {
+            return Array.from(list || []).filter(file => file && file.type && file.type.startsWith('image/'));
+        }
         function App() {
             const [stories, setStories] = useState([]);
             const [page, setPage] = useState(1);
@@ -101,6 +107,7 @@
             const [agentPrompt, setAgentPrompt] = useState('');
             const [agentDate, setAgentDate] = useState('');
             const [agentFiles, setAgentFiles] = useState([]);
+            const [agentFileInputKey, setAgentFileInputKey] = useState(0);
             const [agentJobs, setAgentJobs] = useState([]);
             const [activeJob, setActiveJob] = useState(null);
             const [agentEvents, setAgentEvents] = useState([]);
@@ -200,6 +207,49 @@
                 load(1, q, value);
             };
 
+            const addAgentFiles = files => {
+                const images = imageFilesFromList(files);
+                if (images.length === 0) return;
+                setAgentError('');
+                setAgentFiles(current => {
+                    const next = current.concat(images).slice(0, 3);
+                    if (current.length + images.length > 3) {
+                        setAgentError('Only the first 3 reference images will be used.');
+                    }
+                    return next;
+                });
+            };
+
+            const onAgentFileChange = e => {
+                addAgentFiles(e.target.files || []);
+                setAgentFileInputKey(value => value + 1);
+            };
+
+            const onAgentPromptPaste = e => {
+                const pastedFiles = imageFilesFromList(e.clipboardData && e.clipboardData.files);
+                if (pastedFiles.length > 0) {
+                    addAgentFiles(pastedFiles);
+                    if (!e.clipboardData.getData('text')) {
+                        e.preventDefault();
+                    }
+                    return;
+                }
+                const itemFiles = Array.from((e.clipboardData && e.clipboardData.items) || [])
+                    .filter(item => item.kind === 'file' && item.type.startsWith('image/'))
+                    .map(item => item.getAsFile())
+                    .filter(Boolean);
+                if (itemFiles.length > 0) {
+                    addAgentFiles(itemFiles);
+                    if (!e.clipboardData.getData('text')) {
+                        e.preventDefault();
+                    }
+                }
+            };
+
+            const removeAgentFile = index => {
+                setAgentFiles(files => files.filter((_, i) => i !== index));
+            };
+
             const startAgentJob = async e => {
                 e.preventDefault();
                 setAgentError('');
@@ -220,6 +270,7 @@
                     setAgentPrompt('');
                     setAgentDate('');
                     setAgentFiles([]);
+                    setAgentFileInputKey(value => value + 1);
                 } finally {
                     setAgentBusy(false);
                 }
@@ -256,12 +307,18 @@
                 agentAvailable ? React.createElement('section', { key: 'agent', className: 'agent-panel' }, [
                     React.createElement('h2', { key: 'h' }, 'Generate with Codex'),
                     React.createElement('form', { key: 'f', className: 'agent-form', onSubmit: startAgentJob }, [
-                        React.createElement('textarea', { key: 'p', placeholder: 'Story idea', value: agentPrompt, required: true, maxLength: 4000, onChange: e => setAgentPrompt(e.target.value) }),
+                        React.createElement('textarea', { key: 'p', placeholder: 'Story idea', value: agentPrompt, required: true, maxLength: 4000, onPaste: onAgentPromptPaste, onChange: e => setAgentPrompt(e.target.value) }),
                         React.createElement('div', { key: 'r', className: 'agent-row' }, [
                             React.createElement('input', { key: 'd', type: 'date', value: agentDate, onChange: e => setAgentDate(e.target.value) }),
-                            React.createElement('input', { key: 'i', type: 'file', accept: 'image/jpeg,image/png,image/webp', multiple: true, onChange: e => setAgentFiles(Array.from(e.target.files || []).slice(0, 3)) }),
+                            React.createElement('input', { key: 'i' + agentFileInputKey, type: 'file', accept: 'image/jpeg,image/png,image/webp', multiple: true, onChange: onAgentFileChange }),
                             React.createElement('button', { key: 'b', type: 'submit', disabled: agentBusy || !agentPrompt.trim() }, agentBusy ? 'Starting...' : 'Start')
-                        ])
+                        ]),
+                        agentFiles.length ? React.createElement('div', { key: 'files', className: 'agent-files' }, agentFiles.map((file, index) =>
+                            React.createElement('span', { key: file.name + index, className: 'agent-file' }, [
+                                file.name || 'pasted image',
+                                React.createElement('button', { key: 'x', type: 'button', onClick: () => removeAgentFile(index), 'aria-label': 'Remove reference image' }, 'x')
+                            ])
+                        )) : null
                     ]),
                     agentError ? React.createElement('div', { key: 'err', className: 'agent-error' }, agentError) : null,
                     React.createElement('div', { key: 'jobs', className: 'agent-jobs' }, agentJobs.map(job =>

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -273,7 +273,13 @@ async function cancelSpriteJob(env: Env, jobId: string) {
     const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);
     url.searchParams.append('cmd', 'bash');
     url.searchParams.append('cmd', '-lc');
-    url.searchParams.append('cmd', `pkill -TERM -f ${quoteShell(`story-agent-${jobId}.py`)} || true`);
+    url.searchParams.append(
+        'cmd',
+        [
+            `pkill -TERM -f ${quoteShell(`story-agent-${jobId}.py`)} || true`,
+            `curl -fsS --unix-socket /.sprite/api.sock -X DELETE ${quoteShell(`http://sprite/v1/tasks/story-agent-${jobId}`)} >/dev/null 2>&1 || true`
+        ].join('; ')
+    );
     url.searchParams.set('dir', config.workdir);
     await fetch(url.toString(), {
         method: 'POST',

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -545,6 +545,9 @@ export async function updateRunnerJob(request: Request, env: Env, jobId: string)
     const payload = (await request.json().catch(() => null)) as Record<string, unknown> | null;
     const status = typeof payload?.status === 'string' ? payload.status : '';
     if (!JOB_STATUS.has(status)) return new Response('Invalid status', { status: 400 });
+    if (TERMINAL_STATUS.has(row.status)) {
+        return jsonResponse({ ok: true, ignored: true, status: row.status });
+    }
     const storyId = typeof payload?.story_id === 'number' && Number.isInteger(payload.story_id)
         ? payload.story_id
         : undefined;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,0 +1,553 @@
+import { AuthInfo, Env } from './types';
+import { bearerToken, randomToken, sha256Hex, timingSafeEqualString } from './security';
+import { STORY_AGENT_RUNNER } from './storyAgentRunner';
+
+const DEFAULT_SPRITES_API_BASE = 'https://api.sprites.dev';
+const DEFAULT_SPRITE_NAME = 'bedtime-stories';
+const DEFAULT_SPRITE_WORKDIR = '/home/sprite/bedtimestories/main';
+
+const MAX_AGENT_PROMPT_LENGTH = 4000;
+const MAX_AGENT_MESSAGE_LENGTH = 2000;
+const MAX_AGENT_REF_IMAGES = 3;
+const MAX_AGENT_REF_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_AGENT_EVENT_MESSAGE_LENGTH = 8000;
+const MAX_AGENT_ERROR_LENGTH = 2000;
+const MAX_AGENT_TITLE_LENGTH = 200;
+
+const AGENT_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const JOB_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
+const JOB_STATUS = new Set(['queued', 'starting', 'running', 'complete', 'failed', 'canceled']);
+const TERMINAL_STATUS = new Set(['complete', 'failed', 'canceled']);
+
+interface AgentJobRow {
+    id: string;
+    requested_by: string;
+    prompt: string;
+    target_date: string | null;
+    status: string;
+    sprite_name: string;
+    sprite_session_id: string | null;
+    story_id: number | null;
+    title: string | null;
+    error: string | null;
+    created: string | null;
+    updated: string | null;
+    started: string | null;
+    completed: string | null;
+    callback_token_hash: string;
+}
+
+interface AgentRefRow {
+    id: number;
+    job_id: string;
+    r2_key: string;
+    filename: string;
+    content_type: string;
+}
+
+interface AgentEventRow {
+    id: number;
+    event_type: string;
+    message: string;
+    metadata: string | null;
+    created: string | null;
+}
+
+interface AgentMessageRow {
+    id: number;
+    author_email: string;
+    content: string;
+    created: string | null;
+}
+
+type AgentStatus = 'queued' | 'starting' | 'running' | 'complete' | 'failed' | 'canceled';
+
+function jsonResponse(value: unknown, init?: ResponseInit): Response {
+    const headers = new Headers(init?.headers);
+    headers.set('Content-Type', 'application/json');
+    headers.set('Cache-Control', 'no-store');
+    headers.set('Referrer-Policy', 'no-referrer');
+    return Response.json(value, { ...init, headers });
+}
+
+function textResponse(value: string, init?: ResponseInit): Response {
+    const headers = new Headers(init?.headers);
+    headers.set('Cache-Control', 'no-store');
+    headers.set('Referrer-Policy', 'no-referrer');
+    return new Response(value, { ...init, headers });
+}
+
+function parseAllowedEmails(env: Env): Set<string> {
+    return new Set(
+        (env.STORY_AGENT_ALLOWED_EMAILS || env.AGENT_ALLOWED_EMAILS || '')
+            .split(',')
+            .map(email => email.trim().toLowerCase())
+            .filter(Boolean)
+    );
+}
+
+function agentAuthError(auth: AuthInfo, env: Env): Response | null {
+    if (auth.role !== 'editor' || !auth.email) {
+        return new Response('Forbidden', { status: 403 });
+    }
+    const allowed = parseAllowedEmails(env);
+    if (allowed.size === 0) {
+        return new Response('Story agent allowlist not configured', { status: 503 });
+    }
+    if (!allowed.has(auth.email.toLowerCase())) {
+        return new Response('Forbidden', { status: 403 });
+    }
+    return null;
+}
+
+function validateJobId(jobId: string): boolean {
+    return JOB_ID_RE.test(jobId);
+}
+
+function publicJob(row: AgentJobRow) {
+    return {
+        id: row.id,
+        requested_by: row.requested_by,
+        prompt: row.prompt,
+        target_date: row.target_date,
+        status: row.status,
+        sprite_name: row.sprite_name,
+        story_id: row.story_id,
+        title: row.title,
+        error: row.error,
+        review_url: row.story_id ? `/?id=${row.story_id}` : null,
+        created: row.created,
+        updated: row.updated,
+        started: row.started,
+        completed: row.completed
+    };
+}
+
+function validateDate(value: string): string | null {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        throw new Error('Invalid date');
+    }
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+        throw new Error('Invalid date');
+    }
+    return trimmed;
+}
+
+function uploadExtension(contentType: string): string {
+    if (contentType === 'image/png') return '.png';
+    if (contentType === 'image/webp') return '.webp';
+    return '.jpg';
+}
+
+async function getAuthorizedJob(env: Env, auth: AuthInfo, jobId: string): Promise<AgentJobRow | Response> {
+    if (!validateJobId(jobId)) return new Response('Invalid job id', { status: 400 });
+    const row = await env.DB.prepare('SELECT * FROM story_agent_jobs WHERE id = ?1')
+        .bind(jobId)
+        .first<AgentJobRow>();
+    if (!row) return new Response('Not Found', { status: 404 });
+    if (row.requested_by.toLowerCase() !== auth.email.toLowerCase()) {
+        return new Response('Forbidden', { status: 403 });
+    }
+    return row;
+}
+
+async function getJobForCallback(env: Env, request: Request, jobId: string): Promise<AgentJobRow | Response> {
+    if (!validateJobId(jobId)) return new Response('Invalid job id', { status: 400 });
+    const token = bearerToken(request);
+    if (!token) return new Response('Unauthorized', { status: 401 });
+    const row = await env.DB.prepare('SELECT * FROM story_agent_jobs WHERE id = ?1')
+        .bind(jobId)
+        .first<AgentJobRow>();
+    if (!row) return new Response('Not Found', { status: 404 });
+    const providedHash = await sha256Hex(token);
+    if (!timingSafeEqualString(providedHash, row.callback_token_hash)) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+    return row;
+}
+
+async function appendAgentEvent(
+    env: Env,
+    jobId: string,
+    eventType: string,
+    message: string,
+    metadata?: unknown
+) {
+    const safeEventType = sanitizeEventType(eventType);
+    const safeMessage = message.slice(0, MAX_AGENT_EVENT_MESSAGE_LENGTH);
+    const metadataJson = metadata === undefined ? null : JSON.stringify(metadata).slice(0, 12000);
+    await env.DB.prepare(
+        'INSERT INTO story_agent_events (job_id, event_type, message, metadata, created) VALUES (?1, ?2, ?3, ?4, datetime(\'now\'))'
+    )
+        .bind(jobId, safeEventType, safeMessage, metadataJson)
+        .run();
+}
+
+function sanitizeEventType(value: string): string {
+    const safe = value.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 40);
+    return safe || 'log';
+}
+
+function spriteConfig(env: Env) {
+    return {
+        apiBase: (env.STORY_AGENT_SPRITES_API_BASE || DEFAULT_SPRITES_API_BASE).replace(/\/+$/, ''),
+        token: env.SPRITES_API_TOKEN || env.SPRITE_API_TOKEN || '',
+        spriteName: env.STORY_AGENT_SPRITE_NAME || DEFAULT_SPRITE_NAME,
+        workdir: env.STORY_AGENT_SPRITE_WORKDIR || DEFAULT_SPRITE_WORKDIR
+    };
+}
+
+async function updateJobStatus(
+    env: Env,
+    jobId: string,
+    status: AgentStatus,
+    fields?: { storyId?: number | null; title?: string | null; error?: string | null; sessionId?: string | null }
+) {
+    const setParts = ['status = ?1', "updated = datetime('now')"];
+    const values: (string | number | null)[] = [status];
+    if (status === 'running') setParts.push("started = COALESCE(started, datetime('now'))");
+    if (TERMINAL_STATUS.has(status)) setParts.push("completed = COALESCE(completed, datetime('now'))");
+    if (fields?.storyId !== undefined) {
+        values.push(fields.storyId);
+        setParts.push(`story_id = ?${values.length}`);
+    }
+    if (fields?.title !== undefined) {
+        values.push(fields.title ? fields.title.slice(0, MAX_AGENT_TITLE_LENGTH) : null);
+        setParts.push(`title = ?${values.length}`);
+    }
+    if (fields?.error !== undefined) {
+        values.push(fields.error ? fields.error.slice(0, MAX_AGENT_ERROR_LENGTH) : null);
+        setParts.push(`error = ?${values.length}`);
+    }
+    if (fields?.sessionId !== undefined) {
+        values.push(fields.sessionId);
+        setParts.push(`sprite_session_id = ?${values.length}`);
+    }
+    values.push(jobId);
+    await env.DB.prepare(`UPDATE story_agent_jobs SET ${setParts.join(', ')} WHERE id = ?${values.length}`)
+        .bind(...values)
+        .run();
+}
+
+async function launchSpriteJob(env: Env, origin: string, jobId: string, callbackToken: string) {
+    const config = spriteConfig(env);
+    if (!config.token) {
+        throw new Error('SPRITES_API_TOKEN is not configured');
+    }
+
+    await updateJobStatus(env, jobId, 'starting');
+    await appendAgentEvent(env, jobId, 'status', `Starting Sprite ${config.spriteName}.`);
+
+    const runnerPath = `/tmp/story-agent-${jobId}.py`;
+    const jobUrl = `${origin}/api/agent/jobs/${encodeURIComponent(jobId)}`;
+    const shell = [
+        `runner=${quoteShell(runnerPath)}`,
+        `curl -fsS -H ${quoteShell(`Authorization: Bearer ${callbackToken}`)} ${quoteShell(`${jobUrl}/runner.py`)} -o "$runner"`,
+        'chmod 700 "$runner"',
+        `nohup env STORY_AGENT_JOB_ID=${quoteShell(jobId)} STORY_AGENT_TOKEN=${quoteShell(callbackToken)} STORY_AGENT_BASE_URL=${quoteShell(origin)} STORY_AGENT_WORKDIR=${quoteShell(config.workdir)} PYTHONUNBUFFERED=1 /home/sprite/scripts/.venv/bin/python "$runner" >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
+    ].join(' && ');
+
+    const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);
+    url.searchParams.append('cmd', 'bash');
+    url.searchParams.append('cmd', '-lc');
+    url.searchParams.append('cmd', shell);
+    url.searchParams.set('dir', config.workdir);
+
+    const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${config.token}` }
+    });
+    if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Sprite launch failed (${response.status}): ${body.slice(0, 500)}`);
+    }
+    await appendAgentEvent(env, jobId, 'status', 'Sprite runner launch command accepted.');
+}
+
+async function cancelSpriteJob(env: Env, jobId: string) {
+    const config = spriteConfig(env);
+    if (!config.token) return;
+    const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);
+    url.searchParams.append('cmd', 'bash');
+    url.searchParams.append('cmd', '-lc');
+    url.searchParams.append('cmd', `pkill -TERM -f ${quoteShell(`story-agent-${jobId}.py`)} || true`);
+    url.searchParams.set('dir', config.workdir);
+    await fetch(url.toString(), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${config.token}` }
+    });
+}
+
+function quoteShell(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function formFiles(data: FormData): File[] {
+    const files: File[] = [];
+    for (const name of ['ref_images', 'ref_image', 'refs']) {
+        for (const value of data.getAll(name)) {
+            if (value instanceof File && value.size > 0) files.push(value);
+        }
+    }
+    return files;
+}
+
+export async function createAgentJob(request: Request, env: Env, ctx: ExecutionContext, auth: AuthInfo) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    if (!request.headers.get('content-type')?.includes('multipart/form-data')) {
+        return new Response('Expected multipart/form-data', { status: 400 });
+    }
+    if (!spriteConfig(env).token) {
+        return new Response('SPRITES_API_TOKEN is not configured', { status: 503 });
+    }
+
+    const data = await request.formData();
+    const promptValue = data.get('prompt');
+    const dateValue = data.get('date');
+    if (typeof promptValue !== 'string') {
+        return new Response('Missing prompt', { status: 400 });
+    }
+    const prompt = promptValue.trim();
+    if (!prompt) return new Response('Missing prompt', { status: 400 });
+    if (prompt.length > MAX_AGENT_PROMPT_LENGTH) return new Response('Prompt too long', { status: 400 });
+
+    let targetDate: string | null = null;
+    try {
+        targetDate = typeof dateValue === 'string' ? validateDate(dateValue) : null;
+    } catch {
+        return new Response('Invalid date', { status: 400 });
+    }
+
+    const files = formFiles(data);
+    if (files.length > MAX_AGENT_REF_IMAGES) {
+        return new Response('Too many reference images', { status: 400 });
+    }
+    for (const file of files) {
+        const type = file.type.toLowerCase();
+        if (!AGENT_IMAGE_TYPES.has(type)) return new Response('Unsupported Media Type', { status: 415 });
+        if (file.size > MAX_AGENT_REF_IMAGE_BYTES) return new Response('Payload Too Large', { status: 413 });
+    }
+
+    const jobId = randomToken(18);
+    const callbackToken = randomToken(32);
+    const callbackTokenHash = await sha256Hex(callbackToken);
+    const config = spriteConfig(env);
+    await env.DB.prepare(
+        'INSERT INTO story_agent_jobs (id, requested_by, prompt, target_date, status, sprite_name, callback_token_hash, created, updated) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime(\'now\'), datetime(\'now\'))'
+    )
+        .bind(jobId, auth.email, prompt, targetDate, 'queued', config.spriteName, callbackTokenHash)
+        .run();
+
+    let refIndex = 0;
+    for (const file of files) {
+        refIndex++;
+        const key = `agent-jobs/${jobId}/${crypto.randomUUID()}${uploadExtension(file.type.toLowerCase())}`;
+        await env.IMAGES.put(key, file.stream(), { httpMetadata: { contentType: file.type } });
+        await env.DB.prepare(
+            'INSERT INTO story_agent_refs (job_id, r2_key, filename, content_type, created) VALUES (?1, ?2, ?3, ?4, datetime(\'now\'))'
+        )
+            .bind(jobId, key, file.name || `reference-${refIndex}${uploadExtension(file.type.toLowerCase())}`, file.type)
+            .run();
+    }
+
+    await appendAgentEvent(env, jobId, 'status', 'Story agent job queued.');
+    const origin = new URL(request.url).origin;
+    ctx.waitUntil(
+        launchSpriteJob(env, origin, jobId, callbackToken).catch(async error => {
+            const message = error instanceof Error ? error.message : 'Sprite launch failed';
+            await updateJobStatus(env, jobId, 'failed', { error: message });
+            await appendAgentEvent(env, jobId, 'error', message);
+        })
+    );
+
+    const row = await env.DB.prepare('SELECT * FROM story_agent_jobs WHERE id = ?1')
+        .bind(jobId)
+        .first<AgentJobRow>();
+    return jsonResponse({ job: row ? publicJob(row) : { id: jobId, status: 'queued' } }, { status: 202 });
+}
+
+export async function listAgentJobs(_request: Request, env: Env, auth: AuthInfo) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    const { results } = await env.DB.prepare(
+        'SELECT * FROM story_agent_jobs WHERE LOWER(requested_by) = LOWER(?1) ORDER BY created DESC LIMIT 10'
+    )
+        .bind(auth.email)
+        .all<AgentJobRow>();
+    return jsonResponse({ jobs: results.map(publicJob) });
+}
+
+export async function getAgentJob(_request: Request, env: Env, auth: AuthInfo, jobId: string) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    const row = await getAuthorizedJob(env, auth, jobId);
+    if (row instanceof Response) return row;
+    return jsonResponse({ job: publicJob(row) });
+}
+
+export async function getAgentEvents(request: Request, env: Env, auth: AuthInfo, jobId: string, url: URL) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    const row = await getAuthorizedJob(env, auth, jobId);
+    if (row instanceof Response) return row;
+    const lastHeader = request.headers.get('Last-Event-ID');
+    const after = Number(url.searchParams.get('after') || lastHeader || '0');
+    const safeAfter = Number.isFinite(after) && after > 0 ? Math.floor(after) : 0;
+    const { results } = await env.DB.prepare(
+        'SELECT id, event_type, message, metadata, created FROM story_agent_events WHERE job_id = ?1 AND id > ?2 ORDER BY id ASC LIMIT 100'
+    )
+        .bind(jobId, safeAfter)
+        .all<AgentEventRow>();
+    const chunks = ['retry: 2000\n'];
+    if (results.length === 0) {
+        chunks.push(': heartbeat\n\n');
+    }
+    for (const event of results) {
+        chunks.push(`id: ${event.id}\n`);
+        chunks.push(`event: ${event.event_type}\n`);
+        chunks.push(`data: ${JSON.stringify({
+            message: event.message,
+            metadata: event.metadata ? JSON.parse(event.metadata) : null,
+            created: event.created
+        })}\n\n`);
+    }
+    return textResponse(chunks.join(''), {
+        headers: {
+            'Content-Type': 'text/event-stream',
+            'X-Accel-Buffering': 'no'
+        }
+    });
+}
+
+export async function createAgentMessage(request: Request, env: Env, auth: AuthInfo, jobId: string) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    const row = await getAuthorizedJob(env, auth, jobId);
+    if (row instanceof Response) return row;
+    if (TERMINAL_STATUS.has(row.status)) {
+        return new Response('Job is not active', { status: 409 });
+    }
+    const payload = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+    const content = typeof payload?.content === 'string' ? payload.content.trim() : '';
+    if (!content) return new Response('Missing content', { status: 400 });
+    if (content.length > MAX_AGENT_MESSAGE_LENGTH) return new Response('Message too long', { status: 400 });
+    const result = await env.DB.prepare(
+        'INSERT INTO story_agent_messages (job_id, author_email, content, created) VALUES (?1, ?2, ?3, datetime(\'now\'))'
+    )
+        .bind(jobId, auth.email, content)
+        .run();
+    await appendAgentEvent(env, jobId, 'feedback', 'Feedback queued for Codex.');
+    return jsonResponse({ id: result.meta.last_row_id });
+}
+
+export async function cancelAgentJob(_request: Request, env: Env, ctx: ExecutionContext, auth: AuthInfo, jobId: string) {
+    const authError = agentAuthError(auth, env);
+    if (authError) return authError;
+    const row = await getAuthorizedJob(env, auth, jobId);
+    if (row instanceof Response) return row;
+    if (!TERMINAL_STATUS.has(row.status)) {
+        await updateJobStatus(env, jobId, 'canceled');
+        await appendAgentEvent(env, jobId, 'canceled', 'Job canceled from manage page.');
+        ctx.waitUntil(cancelSpriteJob(env, jobId).catch(() => undefined));
+    }
+    return jsonResponse({ ok: true });
+}
+
+export async function getRunnerScript(request: Request, env: Env, jobId: string) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    return textResponse(STORY_AGENT_RUNNER, {
+        headers: {
+            'Content-Type': 'text/x-python; charset=utf-8'
+        }
+    });
+}
+
+export async function getAgentBootstrap(request: Request, env: Env, jobId: string) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    const { results } = await env.DB.prepare(
+        'SELECT id, filename, content_type FROM story_agent_refs WHERE job_id = ?1 ORDER BY id ASC'
+    )
+        .bind(jobId)
+        .all<{ id: number; filename: string; content_type: string }>();
+    return jsonResponse({
+        id: row.id,
+        prompt: row.prompt,
+        target_date: row.target_date,
+        status: row.status,
+        refs: results.map(ref => ({
+            id: ref.id,
+            filename: ref.filename,
+            content_type: ref.content_type,
+            url: `/api/agent/jobs/${encodeURIComponent(jobId)}/refs/${ref.id}`
+        }))
+    });
+}
+
+export async function getAgentReference(request: Request, env: Env, jobId: string, refId: number) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    const ref = await env.DB.prepare(
+        'SELECT id, job_id, r2_key, filename, content_type FROM story_agent_refs WHERE job_id = ?1 AND id = ?2'
+    )
+        .bind(jobId, refId)
+        .first<AgentRefRow>();
+    if (!ref) return new Response('Not Found', { status: 404 });
+    const object = await env.IMAGES.get(ref.r2_key);
+    if (!object) return new Response('Not Found', { status: 404 });
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set('Cache-Control', 'no-store');
+    headers.set('X-Content-Type-Options', 'nosniff');
+    headers.set('Content-Disposition', `attachment; filename="${ref.filename.replace(/["\r\n]/g, '')}"`);
+    return new Response(object.body, { headers });
+}
+
+export async function getRunnerMessages(request: Request, env: Env, jobId: string, url: URL) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    const after = Number(url.searchParams.get('after') || '0');
+    const safeAfter = Number.isFinite(after) && after > 0 ? Math.floor(after) : 0;
+    const { results } = await env.DB.prepare(
+        'SELECT id, author_email, content, created FROM story_agent_messages WHERE job_id = ?1 AND id > ?2 ORDER BY id ASC LIMIT 25'
+    )
+        .bind(jobId, safeAfter)
+        .all<AgentMessageRow>();
+    return jsonResponse({ messages: results });
+}
+
+export async function createRunnerEvent(request: Request, env: Env, jobId: string) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    const payload = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+    const eventType = typeof payload?.type === 'string' ? payload.type : 'log';
+    const message = typeof payload?.message === 'string' ? payload.message : '';
+    const metadata = payload?.metadata;
+    if (!message) return new Response('Missing message', { status: 400 });
+    await appendAgentEvent(env, jobId, eventType, message, metadata);
+    return jsonResponse({ ok: true });
+}
+
+export async function updateRunnerJob(request: Request, env: Env, jobId: string) {
+    const row = await getJobForCallback(env, request, jobId);
+    if (row instanceof Response) return row;
+    const payload = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+    const status = typeof payload?.status === 'string' ? payload.status : '';
+    if (!JOB_STATUS.has(status)) return new Response('Invalid status', { status: 400 });
+    const storyId = typeof payload?.story_id === 'number' && Number.isInteger(payload.story_id)
+        ? payload.story_id
+        : undefined;
+    const title = typeof payload?.title === 'string' ? payload.title : undefined;
+    const error = typeof payload?.error === 'string' ? payload.error : undefined;
+    await updateJobStatus(env, jobId, status as AgentStatus, { storyId, title, error });
+    await appendAgentEvent(env, jobId, status, `Job status changed to ${status}.`, {
+        story_id: storyId,
+        title
+    });
+    return jsonResponse({ ok: true });
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,6 +2,21 @@ import { AuthInfo, Env, Route, Story } from './types';
 import { markdownToHtml, easternNowIso, htmlToPlainText } from './utils';
 import { signSession, signState, verifyState, verifySession, SESSION_MAXAGE } from './session';
 import { verifyGoogleToken, getAccountRole, requireAuth } from './auth';
+import { timingSafeEqualString } from './security';
+import {
+    cancelAgentJob,
+    createAgentJob,
+    createAgentMessage,
+    createRunnerEvent,
+    getAgentBootstrap,
+    getAgentEvents,
+    getAgentJob,
+    getAgentReference,
+    getRunnerMessages,
+    getRunnerScript,
+    listAgentJobs,
+    updateRunnerJob
+} from './agent';
 
 const CACHE_REFRESH_DEFAULT_DAYS = 5;
 const CACHE_REFRESH_MAX_DAYS = 30;
@@ -61,7 +76,7 @@ function requireStoryToken(request: Request, env: Env): Response | null {
         return new Response('Story API token not configured', { status: 503 });
     }
     const providedToken = request.headers.get(STORY_TOKEN_HEADER);
-    if (!providedToken || providedToken !== requiredToken) {
+    if (!providedToken || !timingSafeEqualString(providedToken, requiredToken)) {
         return new Response('Unauthorized', { status: 401 });
     }
     return null;
@@ -408,6 +423,38 @@ const preAuthRoutes: Route[] = [
     },
     {
         method: 'GET',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)\/runner\.py$/,
+        handler: async (request, env, _ctx, match) => getRunnerScript(request, env, match[1])
+    },
+    {
+        method: 'GET',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)\/bootstrap$/,
+        handler: async (request, env, _ctx, match) => getAgentBootstrap(request, env, match[1])
+    },
+    {
+        method: 'GET',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)\/refs\/(\d+)$/,
+        handler: async (request, env, _ctx, match) =>
+            getAgentReference(request, env, match[1], Number(match[2]))
+    },
+    {
+        method: 'GET',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)\/messages$/,
+        handler: async (request, env, _ctx, match, url) =>
+            getRunnerMessages(request, env, match[1], url)
+    },
+    {
+        method: 'POST',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)\/events$/,
+        handler: async (request, env, _ctx, match) => createRunnerEvent(request, env, match[1])
+    },
+    {
+        method: 'PATCH',
+        pattern: /^\/api\/agent\/jobs\/([A-Za-z0-9_-]+)$/,
+        handler: async (request, env, _ctx, match) => updateRunnerJob(request, env, match[1])
+    },
+    {
+        method: 'GET',
         pattern: /^\/login$/,
         handler: async (_request, env, _ctx, _match, url) => {
             const redirectUri = env.OAUTH_CALLBACK_URL;
@@ -506,6 +553,42 @@ const routes: Route[] = [
         method: 'GET',
         pattern: /^\/bedtime-stories-icon\.png$/,
         handler: (request, env) => env.ASSETS.fetch(request)
+    },
+    {
+        method: 'POST',
+        pattern: /^\/agent\/jobs$/,
+        handler: async (request, env, ctx, _match, _url, auth) =>
+            createAgentJob(request, env, ctx, auth)
+    },
+    {
+        method: 'GET',
+        pattern: /^\/agent\/jobs$/,
+        handler: async (request, env, _ctx, _match, _url, auth) =>
+            listAgentJobs(request, env, auth)
+    },
+    {
+        method: 'GET',
+        pattern: /^\/agent\/jobs\/([A-Za-z0-9_-]+)$/,
+        handler: async (request, env, _ctx, match, _url, auth) =>
+            getAgentJob(request, env, auth, match[1])
+    },
+    {
+        method: 'GET',
+        pattern: /^\/agent\/jobs\/([A-Za-z0-9_-]+)\/events$/,
+        handler: async (request, env, _ctx, match, url, auth) =>
+            getAgentEvents(request, env, auth, match[1], url)
+    },
+    {
+        method: 'POST',
+        pattern: /^\/agent\/jobs\/([A-Za-z0-9_-]+)\/messages$/,
+        handler: async (request, env, _ctx, match, _url, auth) =>
+            createAgentMessage(request, env, auth, match[1])
+    },
+    {
+        method: 'POST',
+        pattern: /^\/agent\/jobs\/([A-Za-z0-9_-]+)\/cancel$/,
+        handler: async (request, env, ctx, match, _url, auth) =>
+            cancelAgentJob(request, env, ctx, auth, match[1])
     },
     {
         method: 'GET',

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,0 +1,37 @@
+const encoder = new TextEncoder();
+
+export function timingSafeEqualString(provided: string, expected: string): boolean {
+    const expectedBytes = encoder.encode(expected);
+    const providedBytes = encoder.encode(provided);
+    if (expectedBytes.length === 0) return false;
+
+    if (providedBytes.length !== expectedBytes.length) {
+        const padded = new Uint8Array(expectedBytes.length);
+        padded.set(providedBytes.slice(0, expectedBytes.length));
+        crypto.subtle.timingSafeEqual(padded, expectedBytes);
+        return false;
+    }
+
+    return crypto.subtle.timingSafeEqual(providedBytes, expectedBytes);
+}
+
+export function bearerToken(request: Request): string | null {
+    const header = request.headers.get('Authorization') || '';
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    return match ? match[1].trim() : null;
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', encoder.encode(value));
+    return [...new Uint8Array(digest)]
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+export function randomToken(bytes = 32): string {
+    const data = new Uint8Array(bytes);
+    crypto.getRandomValues(data);
+    let raw = '';
+    for (const byte of data) raw += String.fromCharCode(byte);
+    return btoa(raw).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -1,0 +1,248 @@
+export const STORY_AGENT_RUNNER = String.raw`#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+BASE_URL = os.environ["STORY_AGENT_BASE_URL"].rstrip("/")
+JOB_ID = os.environ["STORY_AGENT_JOB_ID"]
+JOB_TOKEN = os.environ["STORY_AGENT_TOKEN"]
+WORKDIR = os.environ.get("STORY_AGENT_WORKDIR", "/home/sprite/bedtimestories/main")
+SECRETS_PATH = pathlib.Path.home() / ".config" / "secrets" / "codex.env"
+
+
+def parse_env_value(raw):
+    lexer = shlex.shlex(raw, posix=True)
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    parts = list(lexer)
+    return " ".join(parts)
+
+
+def load_secret_env():
+    if not SECRETS_PATH.exists():
+        return
+    for raw_line in SECRETS_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        name, sep, raw_value = line.partition("=")
+        name = name.strip()
+        if sep and name and not os.environ.get(name):
+            os.environ[name] = parse_env_value(raw_value.strip())
+    if os.environ.get("OPENAI_BEDTIME_STORY_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = os.environ["OPENAI_BEDTIME_STORY_KEY"]
+
+
+def api_request(method, path, payload=None, timeout=30):
+    data = None
+    headers = {
+        "Authorization": "Bearer " + JOB_TOKEN,
+        "Accept": "application/json",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(BASE_URL + path, method=method, headers=headers, data=data)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        body = response.read()
+        if not body:
+            return {}
+        return json.loads(body.decode("utf-8"))
+
+
+def post_event(event_type, message, metadata=None):
+    try:
+        api_request(
+            "POST",
+            "/api/agent/jobs/" + urllib.parse.quote(JOB_ID) + "/events",
+            {"type": event_type, "message": message, "metadata": metadata or {}},
+            timeout=10,
+        )
+    except Exception as exc:
+        print("failed to post event: " + str(exc), file=sys.stderr, flush=True)
+
+
+def patch_job(status, **fields):
+    payload = {"status": status}
+    payload.update(fields)
+    api_request("PATCH", "/api/agent/jobs/" + urllib.parse.quote(JOB_ID), payload, timeout=15)
+
+
+def bootstrap():
+    return api_request("GET", "/api/agent/jobs/" + urllib.parse.quote(JOB_ID) + "/bootstrap")
+
+
+def download_refs(refs):
+    paths = []
+    output_dir = pathlib.Path("/tmp") / ("story-agent-" + JOB_ID)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for ref in refs:
+        filename = ref.get("filename") or ("reference-" + str(ref.get("id", len(paths) + 1)) + ".jpg")
+        safe_name = pathlib.Path(filename).name or ("reference-" + str(len(paths) + 1) + ".jpg")
+        output_path = output_dir / safe_name
+        req = urllib.request.Request(
+            BASE_URL + ref["url"],
+            method="GET",
+            headers={"Authorization": "Bearer " + JOB_TOKEN},
+        )
+        with urllib.request.urlopen(req, timeout=60) as response:
+            output_path.write_bytes(response.read())
+        paths.append(str(output_path))
+    return paths
+
+
+def build_codex_prompt(job, ref_paths):
+    date_line = "No explicit target date was provided."
+    if job.get("target_date"):
+        date_line = "Use this target story date: " + job["target_date"] + "."
+    refs = "\n".join("- " + path for path in ref_paths) if ref_paths else "- none"
+    return (
+        "Use the generate-story skill to create and publish a bedtime story for James.\n\n"
+        "Story idea:\n"
+        + job["prompt"]
+        + "\n\n"
+        + date_line
+        + "\n\nReference image paths:\n"
+        + refs
+        + "\n\nRun the full workflow, including media generation and publishing through the existing story API. "
+        "Stream useful progress as you work. When complete, print exactly one final line in this format:\n"
+        "STORY_AGENT_RESULT_JSON={\"story_id\":123,\"title\":\"Title\",\"image_key\":\"image-key\",\"video_key\":\"video-key\"}\n"
+    )
+
+
+def poll_messages(proc):
+    last_id = 0
+    while proc.poll() is None:
+        try:
+            path = "/api/agent/jobs/" + urllib.parse.quote(JOB_ID) + "/messages?after=" + str(last_id)
+            data = api_request("GET", path, timeout=10)
+            for msg in data.get("messages", []):
+                last_id = max(last_id, int(msg["id"]))
+                content = msg.get("content", "").strip()
+                if content and proc.stdin:
+                    post_event("feedback", "Forwarding feedback to Codex.")
+                    proc.stdin.write("\nUser feedback from the manage page:\n" + content + "\n")
+                    proc.stdin.flush()
+                elif content:
+                    post_event("feedback", "Feedback received while Codex was busy.")
+        except Exception as exc:
+            post_event("warning", "Could not poll feedback: " + str(exc))
+        time.sleep(5)
+
+
+def parse_result(output):
+    marker = "STORY_AGENT_RESULT_JSON="
+    for line in reversed(output.splitlines()):
+        if marker in line:
+            raw = line.split(marker, 1)[1].strip()
+            return json.loads(raw)
+    for match in reversed(re.findall(r"\{[^{}]*\"story_id\"[^{}]*\}", output)):
+        try:
+            return json.loads(match)
+        except Exception:
+            continue
+    return None
+
+
+def main():
+    load_secret_env()
+    job = bootstrap()
+    patch_job("running")
+    post_event("status", "Story agent started in Sprite.")
+    ref_paths = download_refs(job.get("refs", []))
+    if ref_paths:
+        post_event("status", "Downloaded " + str(len(ref_paths)) + " reference image(s).")
+
+    prompt = build_codex_prompt(job, ref_paths)
+    env = os.environ.copy()
+    env["STORY_API_BASE_URL"] = env.get("STORY_API_BASE_URL") or BASE_URL
+    final_message_path = "/tmp/story-agent-" + JOB_ID + "-last-message.txt"
+    cmd = [
+        "codex",
+        "exec",
+        "--json",
+        "--output-last-message",
+        final_message_path,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--cd",
+        WORKDIR,
+        prompt,
+    ]
+    post_event("status", "Launching Codex story workflow.")
+    proc = subprocess.Popen(
+        cmd,
+        cwd=WORKDIR,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    thread = threading.Thread(target=poll_messages, args=(proc,), daemon=True)
+    thread.start()
+
+    output_parts = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        output_parts.append(line)
+        clean = line.rstrip()
+        if clean:
+            post_event("log", clean)
+    exit_code = proc.wait()
+    output = "".join(output_parts)
+    if exit_code != 0:
+        patch_job("failed", error="Codex exited with status " + str(exit_code))
+        post_event("error", "Codex exited with status " + str(exit_code))
+        return exit_code
+
+    final_text = ""
+    final_path = pathlib.Path(final_message_path)
+    if final_path.exists():
+        final_text = final_path.read_text(encoding="utf-8", errors="replace")
+    result = parse_result(final_text + "\n" + output)
+    if not result or not result.get("story_id"):
+        patch_job("failed", error="Codex completed without a story_id result marker.")
+        post_event("error", "Codex completed without a story_id result marker.")
+        return 2
+
+    patch_job(
+        "complete",
+        story_id=int(result["story_id"]),
+        title=str(result.get("title") or ""),
+    )
+    post_event("complete", "Story created.", result)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        post_event("error", "HTTP error " + str(exc.code) + ": " + detail[:500])
+        try:
+            patch_job("failed", error="HTTP error " + str(exc.code))
+        except Exception:
+            pass
+        raise
+    except Exception as exc:
+        post_event("error", str(exc))
+        try:
+            patch_job("failed", error=str(exc))
+        except Exception:
+            pass
+        raise
+`;

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -18,6 +18,8 @@ JOB_ID = os.environ["STORY_AGENT_JOB_ID"]
 JOB_TOKEN = os.environ["STORY_AGENT_TOKEN"]
 WORKDIR = os.environ.get("STORY_AGENT_WORKDIR", "/home/sprite/bedtimestories/main")
 SECRETS_PATH = pathlib.Path.home() / ".config" / "secrets" / "codex.env"
+TASK_NAME = "story-agent-" + JOB_ID
+TASK_EXPIRE = "5m"
 
 
 def parse_env_value(raw):
@@ -60,6 +62,50 @@ def api_request(method, path, payload=None, timeout=30):
         if not body:
             return {}
         return json.loads(body.decode("utf-8"))
+
+
+def task_request(method, path, payload=None):
+    cmd = [
+        "curl",
+        "-fsS",
+        "--unix-socket",
+        "/.sprite/api.sock",
+        "-X",
+        method,
+        "http://sprite" + path,
+    ]
+    if payload is not None:
+        cmd.extend(["-H", "Content-Type: application/json", "-d", json.dumps(payload)])
+    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+
+
+def refresh_task():
+    task_request("PUT", "/v1/tasks/" + urllib.parse.quote(TASK_NAME), {"expire": TASK_EXPIRE})
+
+
+def release_task():
+    subprocess.run(
+        [
+            "curl",
+            "-fsS",
+            "--unix-socket",
+            "/.sprite/api.sock",
+            "-X",
+            "DELETE",
+            "http://sprite/v1/tasks/" + urllib.parse.quote(TASK_NAME),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def heartbeat_task(stop_event):
+    while not stop_event.wait(60):
+        try:
+            refresh_task()
+        except Exception as exc:
+            post_event("warning", "Could not refresh Sprite task hold: " + str(exc))
 
 
 def post_event(event_type, message, metadata=None):
@@ -158,73 +204,83 @@ def parse_result(output):
 
 def main():
     load_secret_env()
-    job = bootstrap()
-    patch_job("running")
-    post_event("status", "Story agent started in Sprite.")
-    ref_paths = download_refs(job.get("refs", []))
-    if ref_paths:
-        post_event("status", "Downloaded " + str(len(ref_paths)) + " reference image(s).")
+    refresh_task()
+    task_stop = threading.Event()
+    task_thread = threading.Thread(target=heartbeat_task, args=(task_stop,), daemon=True)
+    task_thread.start()
+    post_event("status", "Sprite task hold acquired.")
+    try:
+        job = bootstrap()
+        patch_job("running")
+        post_event("status", "Story agent started in Sprite.")
+        ref_paths = download_refs(job.get("refs", []))
+        if ref_paths:
+            post_event("status", "Downloaded " + str(len(ref_paths)) + " reference image(s).")
 
-    prompt = build_codex_prompt(job, ref_paths)
-    env = os.environ.copy()
-    env["STORY_API_BASE_URL"] = env.get("STORY_API_BASE_URL") or BASE_URL
-    final_message_path = "/tmp/story-agent-" + JOB_ID + "-last-message.txt"
-    cmd = [
-        "codex",
-        "exec",
-        "--json",
-        "--output-last-message",
-        final_message_path,
-        "--dangerously-bypass-approvals-and-sandbox",
-        "--cd",
-        WORKDIR,
-        prompt,
-    ]
-    post_event("status", "Launching Codex story workflow.")
-    proc = subprocess.Popen(
-        cmd,
-        cwd=WORKDIR,
-        env=env,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    )
-    thread = threading.Thread(target=poll_messages, args=(proc,), daemon=True)
-    thread.start()
+        prompt = build_codex_prompt(job, ref_paths)
+        env = os.environ.copy()
+        env["STORY_API_BASE_URL"] = env.get("STORY_API_BASE_URL") or BASE_URL
+        final_message_path = "/tmp/story-agent-" + JOB_ID + "-last-message.txt"
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--output-last-message",
+            final_message_path,
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--cd",
+            WORKDIR,
+            prompt,
+        ]
+        post_event("status", "Launching Codex story workflow.")
+        proc = subprocess.Popen(
+            cmd,
+            cwd=WORKDIR,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        thread = threading.Thread(target=poll_messages, args=(proc,), daemon=True)
+        thread.start()
 
-    output_parts = []
-    assert proc.stdout is not None
-    for line in proc.stdout:
-        output_parts.append(line)
-        clean = line.rstrip()
-        if clean:
-            post_event("log", clean)
-    exit_code = proc.wait()
-    output = "".join(output_parts)
-    if exit_code != 0:
-        patch_job("failed", error="Codex exited with status " + str(exit_code))
-        post_event("error", "Codex exited with status " + str(exit_code))
-        return exit_code
+        output_parts = []
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            output_parts.append(line)
+            clean = line.rstrip()
+            if clean:
+                post_event("log", clean)
+        exit_code = proc.wait()
+        output = "".join(output_parts)
+        if exit_code != 0:
+            patch_job("failed", error="Codex exited with status " + str(exit_code))
+            post_event("error", "Codex exited with status " + str(exit_code))
+            return exit_code
 
-    final_text = ""
-    final_path = pathlib.Path(final_message_path)
-    if final_path.exists():
-        final_text = final_path.read_text(encoding="utf-8", errors="replace")
-    result = parse_result(final_text + "\n" + output)
-    if not result or not result.get("story_id"):
-        patch_job("failed", error="Codex completed without a story_id result marker.")
-        post_event("error", "Codex completed without a story_id result marker.")
-        return 2
+        final_text = ""
+        final_path = pathlib.Path(final_message_path)
+        if final_path.exists():
+            final_text = final_path.read_text(encoding="utf-8", errors="replace")
+        result = parse_result(final_text + "\n" + output)
+        if not result or not result.get("story_id"):
+            patch_job("failed", error="Codex completed without a story_id result marker.")
+            post_event("error", "Codex completed without a story_id result marker.")
+            return 2
 
-    patch_job(
-        "complete",
-        story_id=int(result["story_id"]),
-        title=str(result.get("title") or ""),
-    )
-    post_event("complete", "Story created.", result)
-    return 0
+        patch_job(
+            "complete",
+            story_id=int(result["story_id"]),
+            title=str(result.get("title") or ""),
+        )
+        post_event("complete", "Story created.", result)
+        return 0
+    finally:
+        task_stop.set()
+        release_task()
+        post_event("status", "Sprite task hold released.")
 
 
 if __name__ == "__main__":

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -2,7 +2,9 @@ export const STORY_AGENT_RUNNER = String.raw`#!/usr/bin/env python3
 import json
 import os
 import pathlib
+import pty
 import re
+import select
 import shlex
 import subprocess
 import sys
@@ -20,6 +22,7 @@ WORKDIR = os.environ.get("STORY_AGENT_WORKDIR", "/home/sprite/bedtimestories/mai
 SECRETS_PATH = pathlib.Path.home() / ".config" / "secrets" / "codex.env"
 TASK_NAME = "story-agent-" + JOB_ID
 TASK_EXPIRE = "5m"
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)")
 
 
 def parse_env_value(raw):
@@ -180,7 +183,11 @@ def build_codex_prompt(job, ref_paths):
     )
 
 
-def poll_messages(proc):
+def strip_terminal(text):
+    return ANSI_RE.sub("", text).replace("\r", "")
+
+
+def poll_messages(proc, input_fd):
     last_id = 0
     while proc.poll() is None:
         try:
@@ -189,18 +196,19 @@ def poll_messages(proc):
             for msg in data.get("messages", []):
                 last_id = max(last_id, int(msg["id"]))
                 content = msg.get("content", "").strip()
-                if content and proc.stdin:
+                if content:
                     post_event("feedback", "Forwarding feedback to Codex.")
-                    proc.stdin.write("\nUser feedback from the manage page:\n" + content + "\n")
-                    proc.stdin.flush()
-                elif content:
-                    post_event("feedback", "Feedback received while Codex was busy.")
+                    os.write(
+                        input_fd,
+                        ("\nUser feedback from the manage page:\n" + content + "\n").encode("utf-8"),
+                    )
         except Exception as exc:
             post_event("warning", "Could not poll feedback: " + str(exc))
         time.sleep(5)
 
 
 def parse_result(output):
+    output = strip_terminal(output)
     marker = "STORY_AGENT_RESULT_JSON="
     for line in reversed(output.splitlines()):
         if marker in line:
@@ -232,13 +240,9 @@ def main():
         prompt = build_codex_prompt(job, ref_paths)
         env = os.environ.copy()
         env["STORY_API_BASE_URL"] = env.get("STORY_API_BASE_URL") or BASE_URL
-        final_message_path = "/tmp/story-agent-" + JOB_ID + "-last-message.txt"
         cmd = [
             "codex",
-            "exec",
-            "--json",
-            "--output-last-message",
-            final_message_path,
+            "--no-alt-screen",
             "--dangerously-bypass-approvals-and-sandbox",
             "--cd",
             WORKDIR,
@@ -247,38 +251,78 @@ def main():
             cmd.extend(["--image", ref_path])
         cmd.append(prompt)
         post_event("status", "Launching Codex story workflow.")
+        master_fd, slave_fd = pty.openpty()
         proc = subprocess.Popen(
             cmd,
             cwd=WORKDIR,
             env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
         )
-        thread = threading.Thread(target=poll_messages, args=(proc,), daemon=True)
+        os.close(slave_fd)
+        thread = threading.Thread(target=poll_messages, args=(proc, master_fd), daemon=True)
         thread.start()
 
         output_parts = []
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            output_parts.append(line)
-            clean = line.rstrip()
+        line_buffer = ""
+        result = None
+        while True:
+            timeout = 0 if proc.poll() is not None else 1
+            ready, _, _ = select.select([master_fd], [], [], timeout)
+            if not ready:
+                if proc.poll() is not None:
+                    break
+                continue
+            try:
+                chunk = os.read(master_fd, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            text = chunk.decode("utf-8", errors="replace")
+            output_parts.append(text)
+            line_buffer += text
+            while "\n" in line_buffer:
+                line, line_buffer = line_buffer.split("\n", 1)
+                clean = strip_terminal(line).rstrip()
+                if clean:
+                    post_event("log", clean)
+            result = parse_result("".join(output_parts))
+            if result and result.get("story_id"):
+                break
+
+        if line_buffer:
+            clean = strip_terminal(line_buffer).rstrip()
             if clean:
                 post_event("log", clean)
+
+        if result and result.get("story_id"):
+            patch_job(
+                "complete",
+                story_id=int(result["story_id"]),
+                title=str(result.get("title") or ""),
+            )
+            post_event("complete", "Story created.", result)
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+            os.close(master_fd)
+            return 0
+
         exit_code = proc.wait()
+        os.close(master_fd)
         output = "".join(output_parts)
         if exit_code != 0:
             patch_job("failed", error="Codex exited with status " + str(exit_code))
             post_event("error", "Codex exited with status " + str(exit_code))
             return exit_code
 
-        final_text = ""
-        final_path = pathlib.Path(final_message_path)
-        if final_path.exists():
-            final_text = final_path.read_text(encoding="utf-8", errors="replace")
-        result = parse_result(final_text + "\n" + output)
+        result = parse_result(output)
         if not result or not result.get("story_id"):
             patch_job("failed", error="Codex completed without a story_id result marker.")
             post_event("error", "Codex completed without a story_id result marker.")

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -137,7 +137,7 @@ def download_refs(refs):
     for ref in refs:
         filename = ref.get("filename") or ("reference-" + str(ref.get("id", len(paths) + 1)) + ".jpg")
         safe_name = pathlib.Path(filename).name or ("reference-" + str(len(paths) + 1) + ".jpg")
-        output_path = output_dir / safe_name
+        output_path = output_dir / (str(ref.get("id", len(paths) + 1)) + "-" + safe_name)
         req = urllib.request.Request(
             BASE_URL + ref["url"],
             method="GET",
@@ -154,6 +154,16 @@ def build_codex_prompt(job, ref_paths):
     if job.get("target_date"):
         date_line = "Use this target story date: " + job["target_date"] + "."
     refs = "\n".join("- " + path for path in ref_paths) if ref_paths else "- none"
+    reference_instruction = (
+        "No reference images were provided."
+        if not ref_paths
+        else (
+            "Reference images are attached to this Codex request and also stored at the /tmp paths above. "
+            "Inspect them and use visible details as inspiration for the story. "
+            "When running the generate-story workflow, include every listed path as a separate --ref-image argument "
+            "so the media generation provider receives the same references."
+        )
+    )
     return (
         "Use the generate-story skill to create and publish a bedtime story for James.\n\n"
         "Story idea:\n"
@@ -162,6 +172,8 @@ def build_codex_prompt(job, ref_paths):
         + date_line
         + "\n\nReference image paths:\n"
         + refs
+        + "\n\n"
+        + reference_instruction
         + "\n\nRun the full workflow, including media generation and publishing through the existing story API. "
         "Stream useful progress as you work. When complete, print exactly one final line in this format:\n"
         "STORY_AGENT_RESULT_JSON={\"story_id\":123,\"title\":\"Title\",\"image_key\":\"image-key\",\"video_key\":\"video-key\"}\n"
@@ -230,8 +242,10 @@ def main():
             "--dangerously-bypass-approvals-and-sandbox",
             "--cd",
             WORKDIR,
-            prompt,
         ]
+        for ref_path in ref_paths:
+            cmd.extend(["--image", ref_path])
+        cmd.append(prompt)
         post_event("status", "Launching Codex story workflow.")
         proc = subprocess.Popen(
             cmd,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,13 @@ export interface Env {
     CACHE_REFRESH_TOKEN?: string;
     CACHE_REFRESH_DAYS?: string;
     STORY_API_TOKEN?: string;
+    STORY_AGENT_ALLOWED_EMAILS?: string;
+    AGENT_ALLOWED_EMAILS?: string;
+    SPRITES_API_TOKEN?: string;
+    SPRITE_API_TOKEN?: string;
+    STORY_AGENT_SPRITES_API_BASE?: string;
+    STORY_AGENT_SPRITE_NAME?: string;
+    STORY_AGENT_SPRITE_WORKDIR?: string;
 }
 
 export interface AuthInfo {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import worker, { signSession, verifySession, SESSION_MAXAGE } from '../src/index';
 import { getAccountRole } from '../src/auth';
 import { signState } from '../src/session';
+import { sha256Hex } from '../src/security';
 
 interface Story {
     id: number;
@@ -16,6 +17,59 @@ interface Story {
 }
 
 type Account = { email: string; role: 'reader' | 'editor' };
+
+interface AgentJob {
+    id: string;
+    requested_by: string;
+    prompt: string;
+    target_date: string | null;
+    status: string;
+    sprite_name: string;
+    sprite_session_id: string | null;
+    story_id: number | null;
+    title: string | null;
+    error: string | null;
+    callback_token_hash: string;
+    created: string | null;
+    updated: string | null;
+    started: string | null;
+    completed: string | null;
+}
+
+interface AgentRef {
+    id: number;
+    job_id: string;
+    r2_key: string;
+    filename: string;
+    content_type: string;
+}
+
+interface AgentEvent {
+    id: number;
+    job_id: string;
+    event_type: string;
+    message: string;
+    metadata: string | null;
+    created: string | null;
+}
+
+interface AgentMessage {
+    id: number;
+    job_id: string;
+    author_email: string;
+    content: string;
+    created: string | null;
+}
+
+interface AgentState {
+    jobs: AgentJob[];
+    refs: AgentRef[];
+    events: AgentEvent[];
+    messages: AgentMessage[];
+    nextRefId: number;
+    nextEventId: number;
+    nextMessageId: number;
+}
 
 function normalizeAccounts(accounts: (string | Account)[]): Account[] {
     return accounts.map(a =>
@@ -44,7 +98,26 @@ function createAllowedDb(accounts: (string | Account)[]) {
     } as unknown as D1Database;
 }
 
-function createDb(accounts: (string | Account)[], stories: Story[]) {
+function updateAgentJobFromQuery(query: string, params: any[], job: AgentJob) {
+    const setPart = query.match(/SET (.+) WHERE id = \?\d+/)?.[1] || '';
+    const assignments = setPart.split(',').map(part => part.trim()).filter(Boolean);
+    let paramIndex = 0;
+    const now = new Date().toISOString();
+    for (const assignment of assignments) {
+        const field = assignment.split('=')[0].trim() as keyof AgentJob;
+        if (assignment.includes('?')) {
+            (job as any)[field] = params[paramIndex++];
+        } else if (field === 'updated') {
+            job.updated = now;
+        } else if (field === 'started') {
+            job.started = job.started || now;
+        } else if (field === 'completed') {
+            job.completed = job.completed || now;
+        }
+    }
+}
+
+function createDb(accounts: (string | Account)[], stories: Story[], agentState?: AgentState) {
     const acc = normalizeAccounts(accounts);
     return {
         prepare(query: string) {
@@ -68,12 +141,116 @@ function createDb(accounts: (string | Account)[], stories: Story[]) {
                                 const id = params[0];
                                 return (stories.find(s => s.id === id) ?? null) as T;
                             }
+                            if (agentState && query.startsWith('SELECT * FROM story_agent_jobs WHERE id = ?1')) {
+                                return (agentState.jobs.find(job => job.id === params[0]) ?? null) as T;
+                            }
+                            if (agentState && query.includes('FROM story_agent_refs WHERE job_id = ?1 AND id = ?2')) {
+                                return (agentState.refs.find(ref => ref.job_id === params[0] && ref.id === params[1]) ?? null) as T;
+                            }
                             return null as T;
                         },
                         async all<T>() {
+                            if (agentState && query.includes('FROM story_agent_jobs WHERE LOWER(requested_by)')) {
+                                const email = (params[0] as string).toLowerCase();
+                                return {
+                                    results: agentState.jobs
+                                        .filter(job => job.requested_by.toLowerCase() === email)
+                                        .sort((a, b) => (b.created || '').localeCompare(a.created || ''))
+                                        .slice(0, 10) as T[]
+                                };
+                            }
+                            if (agentState && query.includes('FROM story_agent_events WHERE job_id = ?1')) {
+                                const jobId = params[0] as string;
+                                const after = params[1] as number;
+                                return {
+                                    results: agentState.events
+                                        .filter(event => event.job_id === jobId && event.id > after)
+                                        .sort((a, b) => a.id - b.id)
+                                        .slice(0, 100)
+                                        .map(({ id, event_type, message, metadata, created }) => ({ id, event_type, message, metadata, created })) as T[]
+                                };
+                            }
+                            if (agentState && query.includes('FROM story_agent_refs WHERE job_id = ?1 ORDER BY id ASC')) {
+                                const jobId = params[0] as string;
+                                return {
+                                    results: agentState.refs
+                                        .filter(ref => ref.job_id === jobId)
+                                        .sort((a, b) => a.id - b.id)
+                                        .map(({ id, filename, content_type }) => ({ id, filename, content_type })) as T[]
+                                };
+                            }
+                            if (agentState && query.includes('FROM story_agent_messages WHERE job_id = ?1')) {
+                                const jobId = params[0] as string;
+                                const after = params[1] as number;
+                                return {
+                                    results: agentState.messages
+                                        .filter(message => message.job_id === jobId && message.id > after)
+                                        .sort((a, b) => a.id - b.id)
+                                        .slice(0, 25)
+                                        .map(({ id, author_email, content, created }) => ({ id, author_email, content, created })) as T[]
+                                };
+                            }
                             return { results: stories as T[] };
                         },
                         async run() {
+                            if (agentState && query.startsWith('INSERT INTO story_agent_jobs')) {
+                                const now = new Date().toISOString();
+                                agentState.jobs.push({
+                                    id: params[0],
+                                    requested_by: params[1],
+                                    prompt: params[2],
+                                    target_date: params[3],
+                                    status: params[4],
+                                    sprite_name: params[5],
+                                    callback_token_hash: params[6],
+                                    sprite_session_id: null,
+                                    story_id: null,
+                                    title: null,
+                                    error: null,
+                                    created: now,
+                                    updated: now,
+                                    started: null,
+                                    completed: null
+                                });
+                                return { meta: { last_row_id: 1 } };
+                            }
+                            if (agentState && query.startsWith('INSERT INTO story_agent_refs')) {
+                                agentState.refs.push({
+                                    id: agentState.nextRefId++,
+                                    job_id: params[0],
+                                    r2_key: params[1],
+                                    filename: params[2],
+                                    content_type: params[3]
+                                });
+                                return { meta: { last_row_id: agentState.nextRefId - 1 } };
+                            }
+                            if (agentState && query.startsWith('INSERT INTO story_agent_events')) {
+                                agentState.events.push({
+                                    id: agentState.nextEventId++,
+                                    job_id: params[0],
+                                    event_type: params[1],
+                                    message: params[2],
+                                    metadata: params[3],
+                                    created: new Date().toISOString()
+                                });
+                                return { meta: { last_row_id: agentState.nextEventId - 1 } };
+                            }
+                            if (agentState && query.startsWith('INSERT INTO story_agent_messages')) {
+                                agentState.messages.push({
+                                    id: agentState.nextMessageId++,
+                                    job_id: params[0],
+                                    author_email: params[1],
+                                    content: params[2],
+                                    created: new Date().toISOString()
+                                });
+                                return { meta: { last_row_id: agentState.nextMessageId - 1 } };
+                            }
+                            if (agentState && query.startsWith('UPDATE story_agent_jobs SET')) {
+                                const jobId = params[params.length - 1];
+                                const job = agentState.jobs.find(j => j.id === jobId);
+                                if (job) updateAgentJobFromQuery(query, params, job);
+                                return { meta: { last_row_id: 1 } };
+                            }
                             return { meta: { last_row_id: 1 } };
                         }
                     };
@@ -116,6 +293,68 @@ function createImagesPutSpy() {
         }
     } as unknown as R2Bucket;
     return { bucket, getLastPut: () => lastPut };
+}
+
+function createAgentImages() {
+    const store = new Map<string, { value: Uint8Array; contentType: string }>();
+    const bucket = {
+        async put(key: string, value: unknown, options?: any) {
+            let bytes = new Uint8Array();
+            if (value instanceof ReadableStream) {
+                const chunks: Uint8Array[] = [];
+                const reader = value.getReader();
+                while (true) {
+                    const { done, value: chunk } = await reader.read();
+                    if (done) break;
+                    chunks.push(chunk);
+                }
+                const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+                bytes = new Uint8Array(size);
+                let offset = 0;
+                for (const chunk of chunks) {
+                    bytes.set(chunk, offset);
+                    offset += chunk.byteLength;
+                }
+            }
+            store.set(key, {
+                value: bytes,
+                contentType: options?.httpMetadata?.contentType || 'application/octet-stream'
+            });
+        },
+        async get(key: string) {
+            const item = store.get(key);
+            if (!item) return null;
+            return {
+                body: new ReadableStream({
+                    start(controller) {
+                        controller.enqueue(item.value);
+                        controller.close();
+                    }
+                }),
+                size: item.value.byteLength,
+                writeHttpMetadata(headers: Headers) {
+                    headers.set('Content-Type', item.contentType);
+                },
+                httpEtag: 'agent-etag'
+            } as unknown as R2ObjectBody;
+        },
+        async delete(key: string) {
+            store.delete(key);
+        }
+    } as unknown as R2Bucket;
+    return { bucket, store };
+}
+
+function createAgentState(): AgentState {
+    return {
+        jobs: [],
+        refs: [],
+        events: [],
+        messages: [],
+        nextRefId: 1,
+        nextEventId: 1,
+        nextMessageId: 1
+    };
 }
 
 function createImagesWithCounter(store: Record<string, string>) {
@@ -185,6 +424,13 @@ describe('Story page', () => {
                 env.DB = createDb(['test@example.com'], []);
                 env.IMAGES = createImages({});
                 env.PUBLIC_VIEW = 'false';
+                delete (env as any).STORY_AGENT_ALLOWED_EMAILS;
+                delete (env as any).AGENT_ALLOWED_EMAILS;
+                delete (env as any).SPRITES_API_TOKEN;
+                delete (env as any).SPRITE_API_TOKEN;
+                delete (env as any).STORY_AGENT_SPRITES_API_BASE;
+                delete (env as any).STORY_AGENT_SPRITE_NAME;
+                delete (env as any).STORY_AGENT_SPRITE_WORKDIR;
         });
 
         it('signs and verifies JWTs', async () => {
@@ -432,5 +678,201 @@ describe('Story page', () => {
                 data.set('date', 'not-a-date');
                 const response = await workerFetch(new Request('https://example.com/stories', { method: 'POST', body: data, headers: { cookie: `session=${jwt}` } }));
                 expect(response.status).toBe(400);
+        });
+
+        it('requires the separate story agent allowlist for agent endpoints', async () => {
+                const agentState = createAgentState();
+                env.DB = createDb(['test@example.com'], [], agentState);
+                const jwt = await signSession('test@example.com', env);
+
+                let response = await workerFetch('https://example.com/agent/jobs', { headers: { cookie: `session=${jwt}` } });
+                expect(response.status).toBe(503);
+
+                env.STORY_AGENT_ALLOWED_EMAILS = 'owner@example.com';
+                response = await workerFetch('https://example.com/agent/jobs', { headers: { cookie: `session=${jwt}` } });
+                expect(response.status).toBe(403);
+
+                env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                response = await workerFetch('https://example.com/agent/jobs', { headers: { cookie: `session=${jwt}` } });
+                expect(response.status).toBe(200);
+        });
+
+        it('creates story agent jobs and launches the configured Sprite', async () => {
+                const originalFetch = globalThis.fetch;
+                const spriteRequests: string[] = [];
+                globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+                        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+                        if (url.startsWith('https://api.sprites.dev/')) {
+                                spriteRequests.push(url);
+                                expect(init?.headers).toEqual({ Authorization: 'Bearer sprites-token' });
+                                return Response.json({ ok: true });
+                        }
+                        return originalFetch(input as any, init);
+                }) as any;
+
+                try {
+                        const agentState = createAgentState();
+                        const { bucket, store } = createAgentImages();
+                        env.DB = createDb(['test@example.com'], [], agentState);
+                        env.IMAGES = bucket;
+                        env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                        env.SPRITES_API_TOKEN = 'sprites-token';
+                        const jwt = await signSession('test@example.com', env);
+                        const data = new FormData();
+                        data.set('prompt', 'A cozy moon train story');
+                        data.set('date', '2026-06-16');
+                        data.append('ref_images', new File([new Uint8Array([1, 2, 3])], 'moon.jpg', { type: 'image/jpeg' }));
+
+                        const response = await workerFetch(new Request('https://example.com/agent/jobs', {
+                                method: 'POST',
+                                body: data,
+                                headers: { cookie: `session=${jwt}` }
+                        }));
+                        expect(response.status).toBe(202);
+                        const body = await response.json<any>();
+                        expect(body.job.status).toBe('starting');
+                        expect(agentState.jobs).toHaveLength(1);
+                        expect(agentState.jobs[0].status).toBe('starting');
+                        expect(agentState.jobs[0].requested_by).toBe('test@example.com');
+                        expect(agentState.refs).toHaveLength(1);
+                        expect(store.size).toBe(1);
+                        expect(spriteRequests).toHaveLength(1);
+                        const launchUrl = new URL(spriteRequests[0]);
+                        expect(launchUrl.pathname).toBe('/v1/sprites/bedtime-stories/exec');
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('story-agent-');
+                        expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
+                } finally {
+                        globalThis.fetch = originalFetch;
+                }
+        });
+
+        it('authenticates runner callbacks with the per-job token', async () => {
+                const token = 'runner-token';
+                const jobId = 'job_1234567890123456';
+                const agentState = createAgentState();
+                agentState.jobs.push({
+                        id: jobId,
+                        requested_by: 'test@example.com',
+                        prompt: 'A small garden rocket',
+                        target_date: '2026-06-16',
+                        status: 'running',
+                        sprite_name: 'bedtime-stories',
+                        sprite_session_id: null,
+                        story_id: null,
+                        title: null,
+                        error: null,
+                        callback_token_hash: await sha256Hex(token),
+                        created: new Date().toISOString(),
+                        updated: new Date().toISOString(),
+                        started: null,
+                        completed: null
+                });
+                agentState.refs.push({ id: 1, job_id: jobId, r2_key: 'ref.jpg', filename: 'ref.jpg', content_type: 'image/jpeg' });
+                env.DB = createDb(['test@example.com'], [], agentState);
+                env.IMAGES = createImages({ 'ref.jpg': 'ref-data' });
+                env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                const jwt = await signSession('test@example.com', env);
+
+                let response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/bootstrap`);
+                expect(response.status).toBe(401);
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/bootstrap`, {
+                        headers: { Authorization: `Bearer ${token}` }
+                });
+                expect(response.status).toBe(200);
+                const bootstrap = await response.json<any>();
+                expect(bootstrap.prompt).toBe('A small garden rocket');
+                expect(bootstrap.refs[0].url).toBe(`/api/agent/jobs/${jobId}/refs/1`);
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/refs/1`, {
+                        headers: { Authorization: `Bearer ${token}` }
+                });
+                expect(await response.text()).toBe('ref-data');
+
+                response = await workerFetch(`https://example.com/agent/jobs/${jobId}/messages`, {
+                        method: 'POST',
+                        headers: { cookie: `session=${jwt}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ content: 'Make it gentler.' })
+                });
+                expect(response.status).toBe(200);
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/messages?after=0`, {
+                        headers: { Authorization: `Bearer ${token}` }
+                });
+                const messages = await response.json<any>();
+                expect(messages.messages[0].content).toBe('Make it gentler.');
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/events`, {
+                        method: 'POST',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ type: 'log', message: 'working' })
+                });
+                expect(response.status).toBe(200);
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}`, {
+                        method: 'PATCH',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ status: 'complete', story_id: 42, title: 'Garden Rocket' })
+                });
+                expect(response.status).toBe(200);
+                expect(agentState.jobs[0].status).toBe('complete');
+                expect(agentState.jobs[0].story_id).toBe(42);
+
+                response = await workerFetch(`https://example.com/agent/jobs/${jobId}/events`, {
+                        headers: { cookie: `session=${jwt}` }
+                });
+                const events = await response.text();
+                expect(events).toContain('event: log');
+                expect(events).toContain('event: complete');
+        });
+
+        it('cancels active story agent jobs and asks Sprite to stop the runner', async () => {
+                const originalFetch = globalThis.fetch;
+                const spriteRequests: string[] = [];
+                globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+                        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+                        if (url.startsWith('https://api.sprites.dev/')) {
+                                spriteRequests.push(url);
+                                return Response.json({ ok: true });
+                        }
+                        return originalFetch(input as any, init);
+                }) as any;
+
+                try {
+                        const jobId = 'job_abcdef1234567890';
+                        const agentState = createAgentState();
+                        agentState.jobs.push({
+                                id: jobId,
+                                requested_by: 'test@example.com',
+                                prompt: 'A train story',
+                                target_date: null,
+                                status: 'running',
+                                sprite_name: 'bedtime-stories',
+                                sprite_session_id: null,
+                                story_id: null,
+                                title: null,
+                                error: null,
+                                callback_token_hash: await sha256Hex('runner-token'),
+                                created: new Date().toISOString(),
+                                updated: new Date().toISOString(),
+                                started: null,
+                                completed: null
+                        });
+                        env.DB = createDb(['test@example.com'], [], agentState);
+                        env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                        env.SPRITES_API_TOKEN = 'sprites-token';
+                        const jwt = await signSession('test@example.com', env);
+
+                        const response = await workerFetch(`https://example.com/agent/jobs/${jobId}/cancel`, {
+                                method: 'POST',
+                                headers: { cookie: `session=${jwt}` }
+                        });
+                        expect(response.status).toBe(200);
+                        expect(agentState.jobs[0].status).toBe('canceled');
+                        expect(spriteRequests).toHaveLength(1);
+                        expect(new URL(spriteRequests[0]).searchParams.getAll('cmd').join(' ')).toContain(jobId);
+                } finally {
+                        globalThis.fetch = originalFetch;
+                }
         });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -877,10 +877,49 @@ describe('Story page', () => {
                 }
         });
 
+        it('ignores late runner status updates after cancellation', async () => {
+                const token = 'runner-token';
+                const jobId = 'job_latecancel123456';
+                const agentState = createAgentState();
+                agentState.jobs.push({
+                        id: jobId,
+                        requested_by: 'test@example.com',
+                        prompt: 'A train story',
+                        target_date: null,
+                        status: 'canceled',
+                        sprite_name: 'bedtime-stories',
+                        sprite_session_id: null,
+                        story_id: null,
+                        title: null,
+                        error: null,
+                        callback_token_hash: await sha256Hex(token),
+                        created: new Date().toISOString(),
+                        updated: new Date().toISOString(),
+                        started: null,
+                        completed: new Date().toISOString()
+                });
+                env.DB = createDb(['test@example.com'], [], agentState);
+
+                const response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}`, {
+                        method: 'PATCH',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ status: 'complete', story_id: 42, title: 'Too Late' })
+                });
+                expect(response.status).toBe(200);
+                const body = await response.json<any>();
+                expect(body.ignored).toBe(true);
+                expect(agentState.jobs[0].status).toBe('canceled');
+                expect(agentState.jobs[0].story_id).toBeNull();
+                expect(agentState.jobs[0].title).toBeNull();
+        });
+
         it('passes Sprite reference image paths into Codex and generate-story', () => {
                 expect(STORY_AGENT_RUNNER).toContain('Reference images are attached to this Codex request');
                 expect(STORY_AGENT_RUNNER).toContain('--ref-image');
                 expect(STORY_AGENT_RUNNER).toContain('cmd.extend(["--image", ref_path])');
                 expect(STORY_AGENT_RUNNER).toContain('output_dir / (str(ref.get("id", len(paths) + 1)) + "-" + safe_name)');
+                expect(STORY_AGENT_RUNNER).toContain('pty.openpty()');
+                expect(STORY_AGENT_RUNNER).toContain('os.write(');
+                expect(STORY_AGENT_RUNNER).not.toContain('stdin=subprocess.DEVNULL');
         });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -4,6 +4,7 @@ import worker, { signSession, verifySession, SESSION_MAXAGE } from '../src/index
 import { getAccountRole } from '../src/auth';
 import { signState } from '../src/session';
 import { sha256Hex } from '../src/security';
+import { STORY_AGENT_RUNNER } from '../src/storyAgentRunner';
 
 interface Story {
     id: number;
@@ -874,5 +875,12 @@ describe('Story page', () => {
                 } finally {
                         globalThis.fetch = originalFetch;
                 }
+        });
+
+        it('passes Sprite reference image paths into Codex and generate-story', () => {
+                expect(STORY_AGENT_RUNNER).toContain('Reference images are attached to this Codex request');
+                expect(STORY_AGENT_RUNNER).toContain('--ref-image');
+                expect(STORY_AGENT_RUNNER).toContain('cmd.extend(["--image", ref_path])');
+                expect(STORY_AGENT_RUNNER).toContain('output_dir / (str(ref.get("id", len(paths) + 1)) + "-" + safe_name)');
         });
 });


### PR DESCRIPTION
## Summary
- Adds a secure `/manage` workflow for launching agentic bedtime story generation jobs in the preconfigured `bedtime-stories` Sprite.
- Gates job creation, logs, feedback, and cancel actions behind editor auth plus a separate agent allowlist.
- Adds runner callback APIs using per-job bearer tokens so the Sprite can bootstrap, stream events, read feedback, and report completion.

## Changes
- Adds D1 tables for agent jobs, reference images, events, and feedback messages.
- Adds Worker routes for browser job control, SSE event replay, Sprite launch/cancel, and runner callbacks.
- Embeds a Sprite runner that invokes `codex exec` with the `generate-story` workflow and reports the created story id back to the Worker.
- Updates `/manage` with prompt/date/reference image inputs, recent job status, live event output, feedback, cancel, and review links.
- Uses timing-safe comparison for the existing `X-Story-Token` automation API.

## Testing
- `npx tsc --noEmit --pretty false`
- `npm test -- --run`

## Notes
- Deploy requires applying `db/story_agent_tables.sql`.
- Worker secrets required for this feature: `SPRITES_API_TOKEN`, `STORY_AGENT_ALLOWED_EMAILS`, and the existing `STORY_API_TOKEN`.
- The test runtime warns that local Miniflare falls back from compatibility date `2025-05-21` to `2025-05-08`; tests still pass.
