### PR TITLE
Fix story agent Sprite task names

### DIFF
--- a/public/manage.html
+++ b/public/manage.html
@@ -163,6 +163,7 @@
                     const suffix = lastId ? '?after=' + lastId : '';
                     source = new EventSource('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/events' + suffix);
                     const onEvent = event => {
+                        if (typeof event.data !== 'string') return;
                         lastId = Math.max(lastId, Number(event.lastEventId || 0));
                         let data = {};
                         try { data = JSON.parse(event.data); } catch { data = { message: event.data }; }
@@ -172,11 +173,16 @@
                             loadAgentJobs();
                         }
                     };
-                    ['status','log','feedback','warning','error','complete','failed','canceled','running','starting'].forEach(type => source.addEventListener(type, onEvent));
-                    source.onerror = () => {
+                    const onConnectionError = event => {
+                        if (typeof event.data === 'string') {
+                            onEvent(event);
+                            return;
+                        }
                         if (source) source.close();
                         if (!closed) setTimeout(connect, 2500);
                     };
+                    ['status','log','feedback','warning','complete','failed','canceled','running','starting'].forEach(type => source.addEventListener(type, onEvent));
+                    source.addEventListener('error', onConnectionError);
                 };
                 connect();
                 return () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -243,11 +243,12 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
 
     const runnerPath = `/tmp/story-agent-${jobId}.py`;
     const jobUrl = `${origin}/api/agent/jobs/${encodeURIComponent(jobId)}`;
+    const taskName = spriteTaskName(jobId);
     const shell = [
         `runner=${quoteShell(runnerPath)}`,
         `curl -fsS -H ${quoteShell(`Authorization: Bearer ${callbackToken}`)} ${quoteShell(`${jobUrl}/runner.py`)} -o "$runner"`,
         'chmod 700 "$runner"',
-        `nohup env STORY_AGENT_JOB_ID=${quoteShell(jobId)} STORY_AGENT_TOKEN=${quoteShell(callbackToken)} STORY_AGENT_BASE_URL=${quoteShell(origin)} STORY_AGENT_WORKDIR=${quoteShell(config.workdir)} PYTHONUNBUFFERED=1 /home/sprite/scripts/.venv/bin/python "$runner" >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
+        `nohup env STORY_AGENT_JOB_ID=${quoteShell(jobId)} STORY_AGENT_TOKEN=${quoteShell(callbackToken)} STORY_AGENT_BASE_URL=${quoteShell(origin)} STORY_AGENT_WORKDIR=${quoteShell(config.workdir)} STORY_AGENT_TASK_NAME=${quoteShell(taskName)} PYTHONUNBUFFERED=1 /home/sprite/scripts/.venv/bin/python "$runner" >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
     ].join(' && ');
 
     const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);
@@ -270,6 +271,7 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
 async function cancelSpriteJob(env: Env, jobId: string) {
     const config = spriteConfig(env);
     if (!config.token) return;
+    const taskName = spriteTaskName(jobId);
     const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);
     url.searchParams.append('cmd', 'bash');
     url.searchParams.append('cmd', '-lc');
@@ -277,7 +279,7 @@ async function cancelSpriteJob(env: Env, jobId: string) {
         'cmd',
         [
             `pkill -TERM -f ${quoteShell(`story-agent-${jobId}.py`)} || true`,
-            `curl -fsS --unix-socket /.sprite/api.sock -X DELETE ${quoteShell(`http://sprite/v1/tasks/story-agent-${jobId}`)} >/dev/null 2>&1 || true`
+            `curl -fsS --unix-socket /.sprite/api.sock -X DELETE ${quoteShell(`http://sprite/v1/tasks/${taskName}`)} >/dev/null 2>&1 || true`
         ].join('; ')
     );
     url.searchParams.set('dir', config.workdir);
@@ -289,6 +291,10 @@ async function cancelSpriteJob(env: Env, jobId: string) {
 
 function quoteShell(value: string): string {
     return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function spriteTaskName(jobId: string): string {
+    return `story-agent-${jobId}`.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '') || 'story-agent';
 }
 
 function formFiles(data: FormData): File[] {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -242,13 +242,30 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
     await appendAgentEvent(env, jobId, 'status', `Starting Sprite ${config.spriteName}.`);
 
     const runnerPath = `/tmp/story-agent-${jobId}.py`;
+    const envPath = `/tmp/story-agent-${jobId}.env`;
     const jobUrl = `${origin}/api/agent/jobs/${encodeURIComponent(jobId)}`;
     const taskName = spriteTaskName(jobId);
+    const runnerEnv = [
+        `export STORY_AGENT_JOB_ID=${quoteShell(jobId)}`,
+        `export STORY_AGENT_TOKEN=${quoteShell(callbackToken)}`,
+        `export STORY_AGENT_BASE_URL=${quoteShell(origin)}`,
+        `export STORY_AGENT_WORKDIR=${quoteShell(config.workdir)}`,
+        `export STORY_AGENT_TASK_NAME=${quoteShell(taskName)}`,
+        'export PYTHONUNBUFFERED=1'
+    ].join('\n');
+    const runScript = [
+        `. ${quoteShell(envPath)}`,
+        `rm -f ${quoteShell(envPath)}`,
+        `exec /home/sprite/scripts/.venv/bin/python ${quoteShell(runnerPath)}`
+    ].join(' && ');
     const shell = [
         `runner=${quoteShell(runnerPath)}`,
+        `envfile=${quoteShell(envPath)}`,
         `curl -fsS -H ${quoteShell(`Authorization: Bearer ${callbackToken}`)} ${quoteShell(`${jobUrl}/runner.py`)} -o "$runner"`,
         'chmod 700 "$runner"',
-        `nohup env STORY_AGENT_JOB_ID=${quoteShell(jobId)} STORY_AGENT_TOKEN=${quoteShell(callbackToken)} STORY_AGENT_BASE_URL=${quoteShell(origin)} STORY_AGENT_WORKDIR=${quoteShell(config.workdir)} STORY_AGENT_TASK_NAME=${quoteShell(taskName)} PYTHONUNBUFFERED=1 /home/sprite/scripts/.venv/bin/python "$runner" >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
+        `cat > "$envfile" <<'STORY_AGENT_ENV'\n${runnerEnv}\nSTORY_AGENT_ENV`,
+        'chmod 600 "$envfile"',
+        `nohup bash -lc ${quoteShell(runScript)} >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
     ].join(' && ');
 
     const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -20,7 +20,11 @@ JOB_ID = os.environ["STORY_AGENT_JOB_ID"]
 JOB_TOKEN = os.environ["STORY_AGENT_TOKEN"]
 WORKDIR = os.environ.get("STORY_AGENT_WORKDIR", "/home/sprite/bedtimestories/main")
 SECRETS_PATH = pathlib.Path.home() / ".config" / "secrets" / "codex.env"
-TASK_NAME = "story-agent-" + JOB_ID
+TASK_NAME = os.environ.get("STORY_AGENT_TASK_NAME") or re.sub(
+    r"[^a-z0-9-]+",
+    "-",
+    ("story-agent-" + JOB_ID).lower(),
+).strip("-")
 TASK_EXPIRE = "5m"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)")
 

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -1,5 +1,6 @@
 export const STORY_AGENT_RUNNER = String.raw`#!/usr/bin/env python3
 import json
+import hashlib
 import os
 import pathlib
 import pty
@@ -27,6 +28,10 @@ TASK_NAME = os.environ.get("STORY_AGENT_TASK_NAME") or re.sub(
 ).strip("-")
 TASK_EXPIRE = "5m"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)")
+
+
+def token_hash_prefix():
+    return hashlib.sha256(JOB_TOKEN.encode("utf-8")).hexdigest()[:12]
 
 
 def parse_env_value(raw):
@@ -122,6 +127,16 @@ def post_event(event_type, message, metadata=None):
             "/api/agent/jobs/" + urllib.parse.quote(JOB_ID) + "/events",
             {"type": event_type, "message": message, "metadata": metadata or {}},
             timeout=10,
+        )
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        print(
+            "failed to post event: HTTP Error "
+            + str(exc.code)
+            + ": "
+            + detail[:500],
+            file=sys.stderr,
+            flush=True,
         )
     except Exception as exc:
         print("failed to post event: " + str(exc), file=sys.stderr, flush=True)
@@ -228,6 +243,7 @@ def parse_result(output):
 
 def main():
     load_secret_env()
+    print("story agent runner started; callback token hash prefix " + token_hash_prefix(), flush=True)
     refresh_task()
     task_stop = threading.Event()
     task_thread = threading.Thread(target=heartbeat_task, args=(task_stop,), daemon=True)
@@ -350,6 +366,7 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
+        print("HTTP error " + str(exc.code) + ": " + detail[:500], file=sys.stderr, flush=True)
         post_event("error", "HTTP error " + str(exc.code) + ": " + detail[:500])
         try:
             patch_job("failed", error="HTTP error " + str(exc.code))

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -741,6 +741,7 @@ describe('Story page', () => {
                         const launchUrl = new URL(spriteRequests[0]);
                         expect(launchUrl.pathname).toBe('/v1/sprites/bedtime-stories/exec');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('story-agent-');
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('STORY_AGENT_TASK_NAME=');
                         expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
                 } finally {
                         globalThis.fetch = originalFetch;
@@ -840,7 +841,7 @@ describe('Story page', () => {
                 }) as any;
 
                 try {
-                        const jobId = 'job_abcdef1234567890';
+                        const jobId = 'job_ABCdef1234567890';
                         const agentState = createAgentState();
                         agentState.jobs.push({
                                 id: jobId,
@@ -872,6 +873,7 @@ describe('Story page', () => {
                         expect(agentState.jobs[0].status).toBe('canceled');
                         expect(spriteRequests).toHaveLength(1);
                         expect(new URL(spriteRequests[0]).searchParams.getAll('cmd').join(' ')).toContain(jobId);
+                        expect(new URL(spriteRequests[0]).searchParams.getAll('cmd').join(' ')).toContain('http://sprite/v1/tasks/story-agent-job-abcdef1234567890');
                 } finally {
                         globalThis.fetch = originalFetch;
                 }
@@ -921,5 +923,7 @@ describe('Story page', () => {
                 expect(STORY_AGENT_RUNNER).toContain('pty.openpty()');
                 expect(STORY_AGENT_RUNNER).toContain('os.write(');
                 expect(STORY_AGENT_RUNNER).not.toContain('stdin=subprocess.DEVNULL');
+                expect(STORY_AGENT_RUNNER).toContain('STORY_AGENT_TASK_NAME');
+                expect(STORY_AGENT_RUNNER).toContain('("story-agent-" + JOB_ID).lower()');
         });
 });


### PR DESCRIPTION
## Summary
- Fix story agent jobs crashing before Codex starts when the generated job id contains uppercase characters or underscores.
- Stop `/manage` from displaying browser EventSource reconnects as blank `[error]` log entries.
- Harden the Sprite runner launch so callback credentials are sourced from a short-lived private env file and callback failures leave useful local diagnostics.

## Changes
- Pass a Sprite-safe lowercase task name into the runner and use the same sanitized name when canceling a job.
- Keep the runner fallback task-name derivation compatible with Sprite task-name validation.
- Separate real server `event: error` messages from connection-level EventSource errors in the management UI.
- Start the runner via a temporary `0600` env file that is removed before the Python runner execs.
- Add local Sprite-log diagnostics for callback HTTP failures without printing secret token values.
- Add regression assertions for the task-name contract.

## Testing
- `npx tsc --noEmit --pretty false`
- `npm test -- --run`
- `python3 -m py_compile /tmp/storyAgentRunner.py`
- `git diff --check`

## Notes
- This fix has already been deployed manually with Wrangler as Worker version `5d2f8f3c-d4d0-457a-9a9d-f595c00aed7f`.
