### PR TITLE
Fix story agent launcher env file write

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -243,16 +243,18 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
 
     const runnerPath = `/tmp/story-agent-${jobId}.py`;
     const envPath = `/tmp/story-agent-${jobId}.env`;
+    const logPath = `/tmp/story-agent-${jobId}.log`;
     const jobUrl = `${origin}/api/agent/jobs/${encodeURIComponent(jobId)}`;
     const taskName = spriteTaskName(jobId);
-    const runnerEnv = [
+    const runnerEnvLines = [
         `export STORY_AGENT_JOB_ID=${quoteShell(jobId)}`,
         `export STORY_AGENT_TOKEN=${quoteShell(callbackToken)}`,
         `export STORY_AGENT_BASE_URL=${quoteShell(origin)}`,
         `export STORY_AGENT_WORKDIR=${quoteShell(config.workdir)}`,
         `export STORY_AGENT_TASK_NAME=${quoteShell(taskName)}`,
         'export PYTHONUNBUFFERED=1'
-    ].join('\n');
+    ];
+    const writeEnvCommand = `umask 077; printf '%s\\n' ${runnerEnvLines.map(quoteShell).join(' ')} > "$envfile"`;
     const runScript = [
         `. ${quoteShell(envPath)}`,
         `rm -f ${quoteShell(envPath)}`,
@@ -261,11 +263,15 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
     const shell = [
         `runner=${quoteShell(runnerPath)}`,
         `envfile=${quoteShell(envPath)}`,
-        `curl -fsS -H ${quoteShell(`Authorization: Bearer ${callbackToken}`)} ${quoteShell(`${jobUrl}/runner.py`)} -o "$runner"`,
+        `logfile=${quoteShell(logPath)}`,
+        ': > "$logfile"',
+        `printf '%s\\n' ${quoteShell('launcher: downloading runner')} >> "$logfile"`,
+        `curl -fsS -H ${quoteShell(`Authorization: Bearer ${callbackToken}`)} ${quoteShell(`${jobUrl}/runner.py`)} -o "$runner" >> "$logfile" 2>&1`,
         'chmod 700 "$runner"',
-        `cat > "$envfile" <<'STORY_AGENT_ENV'\n${runnerEnv}\nSTORY_AGENT_ENV`,
-        'chmod 600 "$envfile"',
-        `nohup bash -lc ${quoteShell(runScript)} >> ${quoteShell(`/tmp/story-agent-${jobId}.log`)} 2>&1 &`
+        writeEnvCommand,
+        `printf '%s\\n' ${quoteShell('launcher: starting runner')} >> "$logfile"`,
+        `nohup bash -lc ${quoteShell(runScript)} >> "$logfile" 2>&1 &`,
+        `printf '%s\\n' ${quoteShell('launcher: runner launch returned')} >> "$logfile"`
     ].join(' && ');
 
     const url = new URL(`${config.apiBase}/v1/sprites/${encodeURIComponent(config.spriteName)}/exec`);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -742,6 +742,8 @@ describe('Story page', () => {
                         expect(launchUrl.pathname).toBe('/v1/sprites/bedtime-stories/exec');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('story-agent-');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('STORY_AGENT_TASK_NAME=');
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain("printf '%s\\n'");
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('STORY_AGENT_ENV');
                         expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
                 } finally {
                         globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Fix the Sprite launcher command so it creates the runner env file without using a here-doc inside the Sprites exec query command.
- Add launcher log markers before the background runner starts, so shell-level launch failures leave evidence in `/tmp/story-agent-<job>.log`.

## Changes
- Replace the `cat <<STORY_AGENT_ENV` launch step with a `printf '%s\n' ... > "$envfile"` command.
- Create/truncate the story-agent log before downloading the runner.
- Append launcher progress markers around runner download and `nohup` startup.
- Add a regression assertion that the launch command uses `printf` and does not include the here-doc marker.

## Testing
- `npx tsc --noEmit --pretty false`
- `npm test -- --run`
- `python3 -m py_compile /tmp/storyAgentRunner.py`
- `git diff --check`

## Notes
- Deployed manually with Wrangler as Worker version `bbd31717-faf7-4265-99bf-31212d2b5d91`.
- Marked the stale pre-fix job `zH93JoGw-9sKY9oJQwfyFWCm` as failed because it had no runner process, no Sprite task hold, and no runner log.
