### PR TITLE
Fix story agent background launch shell

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -254,7 +254,7 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
         `export STORY_AGENT_TASK_NAME=${quoteShell(taskName)}`,
         'export PYTHONUNBUFFERED=1'
     ];
-    const writeEnvCommand = `umask 077; printf '%s\\n' ${runnerEnvLines.map(quoteShell).join(' ')} > "$envfile"`;
+    const writeEnvCommand = `umask 077 && printf '%s\\n' ${runnerEnvLines.map(quoteShell).join(' ')} > "$envfile"`;
     const runScript = [
         `. ${quoteShell(envPath)}`,
         `rm -f ${quoteShell(envPath)}`,
@@ -270,7 +270,7 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
         'chmod 700 "$runner"',
         writeEnvCommand,
         `printf '%s\\n' ${quoteShell('launcher: starting runner')} >> "$logfile"`,
-        `nohup bash -lc ${quoteShell(runScript)} >> "$logfile" 2>&1 &`,
+        `( nohup bash -lc ${quoteShell(runScript)} >> "$logfile" 2>&1 & )`,
         `printf '%s\\n' ${quoteShell('launcher: runner launch returned')} >> "$logfile"`
     ].join(' && ');
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -744,6 +744,7 @@ describe('Story page', () => {
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('STORY_AGENT_TASK_NAME=');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain("printf '%s\\n'");
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('STORY_AGENT_ENV');
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('& &&');
                         expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
                 } finally {
                         globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Fix the story-agent launcher shell so the background `nohup` command does not produce invalid `& &&` syntax.
- This is the reason recent jobs warmed the Sprite but never created `/tmp/story-agent-<job>.log` or started Codex.

## Changes
- Run the background `nohup` inside a subshell before continuing the `&&` chain.
- Change env-file creation from `umask 077; printf ...` to `umask 077 && printf ...` so failures stop the launcher.
- Add a regression assertion that the generated launch command cannot contain `& &&`.

## Testing
- `npx tsc --noEmit --pretty false`
- `npm test -- --run`
- `python3 -m py_compile /tmp/storyAgentRunner.py`
- `git diff --check`
- Verified a harmless command through the same Sprites REST `/exec?cmd=bash&cmd=-lc&cmd=...` path writes its log successfully with the corrected subshell form.

## Notes
- Deployed manually with Wrangler as Worker version `6066eea9-635f-4ef5-a8b4-12040a2feef8`.
- Marked stale pre-fix job `Qvx4UsUUOC5FbC9WRirNhojq` as failed because it had no runner process, no Sprite task hold, and no runner log.
