### PR TITLE
Fix story agent Codex runner automation

### DIFF
--- a/.codex/skills/generate-story/SKILL.md
+++ b/.codex/skills/generate-story/SKILL.md
@@ -38,6 +38,7 @@ Required env vars:
 - `OPENAI_API_KEY` for `openai-media`, `openai-image`, or `openai-video`
   - `OPENAI_BEDTIME_STORY_KEY` is also accepted as a local alias by the bundled scripts
 - `STORY_API_BASE_URL` (optional, defaults to `https://bedtimestories.bruce-hart.workers.dev`)
+- `STORY_API_USER_AGENT` (optional, defaults to a browser-like user agent for Cloudflare Browser Integrity Check compatibility)
 
 The bundled scripts will also auto-load `$HOME/.config/secrets/codex.env` when these vars are not already exported.
 
@@ -276,12 +277,14 @@ Upload media:
 
 ```bash
 curl -s "${STORY_API_BASE_URL:-https://bedtimestories.bruce-hart.workers.dev}/api/media" \
+  -A "${STORY_API_USER_AGENT:-Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36}" \
   -H "X-Story-Token: $STORY_API_TOKEN" \
   -F "file=@/path/to/image.jpg"
 ```
 
 ```bash
 curl -s "${STORY_API_BASE_URL:-https://bedtimestories.bruce-hart.workers.dev}/api/media" \
+  -A "${STORY_API_USER_AGENT:-Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36}" \
   -H "X-Story-Token: $STORY_API_TOKEN" \
   -F "file=@/tmp/story-video-encoded.mp4"
 ```
@@ -290,6 +293,7 @@ Create story:
 
 ```bash
 curl -s "${STORY_API_BASE_URL:-https://bedtimestories.bruce-hart.workers.dev}/api/stories" \
+  -A "${STORY_API_USER_AGENT:-Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36}" \
   -H "X-Story-Token: $STORY_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/.codex/skills/generate-story/scripts/next-open-date.py
+++ b/.codex/skills/generate-story/scripts/next-open-date.py
@@ -7,7 +7,7 @@ import urllib.parse
 import urllib.request
 from zoneinfo import ZoneInfo
 
-from story_media_common import load_default_secret_env
+from story_media_common import load_default_secret_env, story_api_user_agent
 
 DEFAULT_BASE_URL = "https://bedtimestories.bruce-hart.workers.dev"
 DEFAULT_RANGE_DAYS = 365
@@ -37,11 +37,7 @@ def fetch_calendar_days(base_url: str, start: datetime.date, end: datetime.date,
     url = f"{base_url}/api/stories/calendar?{params}"
     req = urllib.request.Request(url)
     req.add_header("X-Story-Token", story_token)
-    req.add_header(
-        "User-Agent",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    )
+    req.add_header("User-Agent", story_api_user_agent())
     req.add_header("Accept", "application/json")
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:

--- a/.codex/skills/generate-story/scripts/run-generate-story.py
+++ b/.codex/skills/generate-story/scripts/run-generate-story.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import uuid
 
-from story_media_common import load_default_secret_env, require_env
+from story_media_common import load_default_secret_env, require_env, story_api_user_agent
 
 
 DEFAULT_BASE_URL = "https://bedtimestories.bruce-hart.workers.dev"
@@ -41,7 +41,7 @@ def curl_json(args: list[str]) -> dict:
     # args: curl arguments excluding -sS; must include URL and any headers/body flags.
     out_path = tempfile.mktemp(prefix="story-curl-", suffix=".json", dir="/tmp")
     code = subprocess.run(
-        ["curl", "-sS", "-o", out_path, "-w", "%{http_code}", *args],
+        ["curl", "-sS", "-A", story_api_user_agent(), "-o", out_path, "-w", "%{http_code}", *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/.codex/skills/generate-story/scripts/story_media_common.py
+++ b/.codex/skills/generate-story/scripts/story_media_common.py
@@ -13,6 +13,10 @@ DEFAULT_SECRETS_ENV_PATH = pathlib.Path.home() / ".config" / "secrets" / "codex.
 ENV_ALIASES = {
     "OPENAI_API_KEY": ("OPENAI_BEDTIME_STORY_KEY",),
 }
+DEFAULT_STORY_API_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
 
 
 def parse_env_value(raw: str) -> str:
@@ -68,6 +72,10 @@ def require_env(name: str) -> str:
     raise SystemExit(
         f"{name} is required (export it in the current environment or set it{alias_hint} in {DEFAULT_SECRETS_ENV_PATH})."
     )
+
+
+def story_api_user_agent() -> str:
+    return os.getenv("STORY_API_USER_AGENT", DEFAULT_STORY_API_USER_AGENT)
 
 
 def request_json(

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Optional vars:
 - `STORY_AGENT_SPRITE_NAME` – defaults to `bedtime-stories`.
 - `STORY_AGENT_SPRITE_WORKDIR` – defaults to `/home/sprite/bedtimestories/main`.
 - `STORY_AGENT_SPRITES_API_BASE` – defaults to `https://api.sprites.dev`.
+- `STORY_API_USER_AGENT` – browser-like user agent used by Sprite-side story API calls; override only if Cloudflare Browser Integrity Check starts blocking the default.
 
 The runner creates a Sprite task hold while Codex is actively generating a story,
 refreshes it during the run, and releases it when the job completes or fails.
@@ -109,6 +110,11 @@ task hold, making the Sprite eligible to pause when idle.
 When reference images are included, the Worker stores them in R2, the runner
 downloads them into `/tmp` on the Sprite, attaches them to Codex, and instructs
 Codex to pass each path to `generate-story` as `--ref-image`.
+If Sprite logs show Cloudflare Error 1010 (`browser_signature_banned`) on
+`/api/agent` callbacks, deploy the current Worker code so the runner uses the
+browser-like user agent. If the account-level security rule still blocks the
+Sprite, disable Browser Integrity Check selectively for the authenticated
+automation API paths rather than disabling story-agent authentication.
 
 ### Security Notes
 

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -188,8 +188,8 @@ def build_codex_prompt(job, ref_paths):
         "No reference images were provided."
         if not ref_paths
         else (
-            "Reference images are attached to this Codex request and also stored at the /tmp paths above. "
-            "Inspect them and use visible details as inspiration for the story. "
+            "Reference images are available at the /tmp paths above. "
+            "Inspect those files directly and use visible details as inspiration for the story. "
             "When running the generate-story workflow, include every listed path as a separate --ref-image argument "
             "so the media generation provider receives the same references."
         )
@@ -205,8 +205,9 @@ def build_codex_prompt(job, ref_paths):
         + "\n\n"
         + reference_instruction
         + "\n\nRun the full workflow, including media generation and publishing through the existing story API. "
-        "Stream useful progress as you work. When complete, print exactly one final line in this format:\n"
-        "STORY_AGENT_RESULT_JSON={\"story_id\":123,\"title\":\"Title\",\"image_key\":\"image-key\",\"video_key\":\"video-key\"}\n"
+        "Stream useful progress as you work. When complete, print exactly one final line beginning with "
+        "STORY_AGENT_RESULT_JSON= followed by compact JSON containing the actual story_id, title, image_key, "
+        "and video_key returned by the publishing workflow. Do not print placeholder values or example JSON.\n"
     )
 
 
@@ -240,13 +241,35 @@ def parse_result(output):
     for line in reversed(output.splitlines()):
         if marker in line:
             raw = line.split(marker, 1)[1].strip()
-            return json.loads(raw)
+            try:
+                parsed = json.loads(raw)
+                if is_real_result(parsed):
+                    return parsed
+            except Exception:
+                continue
     for match in reversed(re.findall(r"\{[^{}]*\"story_id\"[^{}]*\}", output)):
         try:
-            return json.loads(match)
+            parsed = json.loads(match)
+            if is_real_result(parsed):
+                return parsed
         except Exception:
             continue
     return None
+
+
+def is_real_result(value):
+    if not isinstance(value, dict):
+        return False
+    story_id = value.get("story_id")
+    if not isinstance(story_id, int) or story_id <= 0:
+        return False
+    if value.get("title") == "Title":
+        return False
+    if value.get("image_key") == "image-key":
+        return False
+    if value.get("video_key") == "video-key":
+        return False
+    return True
 
 
 def main():
@@ -268,15 +291,22 @@ def main():
         prompt = build_codex_prompt(job, ref_paths)
         env = os.environ.copy()
         env["STORY_API_BASE_URL"] = env.get("STORY_API_BASE_URL") or BASE_URL
+        result_path = pathlib.Path("/tmp") / ("story-agent-" + JOB_ID + "-codex-result.txt")
+        try:
+            result_path.unlink()
+        except FileNotFoundError:
+            pass
         cmd = [
             "codex",
-            "--no-alt-screen",
+            "exec",
             "--dangerously-bypass-approvals-and-sandbox",
             "--cd",
             WORKDIR,
+            "--color",
+            "never",
+            "--output-last-message",
+            str(result_path),
         ]
-        for ref_path in ref_paths:
-            cmd.extend(["--image", ref_path])
         cmd.append(prompt)
         post_event("status", "Launching Codex story workflow.")
         master_fd, slave_fd = pty.openpty()
@@ -290,18 +320,25 @@ def main():
             close_fds=True,
         )
         os.close(slave_fd)
+        post_event("status", "Codex exec process started with pid " + str(proc.pid) + ".")
         thread = threading.Thread(target=poll_messages, args=(proc, master_fd), daemon=True)
         thread.start()
 
         output_parts = []
         line_buffer = ""
         result = None
+        last_output_at = time.time()
+        last_idle_event_at = last_output_at
         while True:
             timeout = 0 if proc.poll() is not None else 1
             ready, _, _ = select.select([master_fd], [], [], timeout)
             if not ready:
                 if proc.poll() is not None:
                     break
+                now = time.time()
+                if now - last_output_at > 120 and now - last_idle_event_at > 120:
+                    post_event("status", "Codex exec is still running; waiting for output.")
+                    last_idle_event_at = now
                 continue
             try:
                 chunk = os.read(master_fd, 4096)
@@ -310,6 +347,7 @@ def main():
             if not chunk:
                 break
             text = chunk.decode("utf-8", errors="replace")
+            last_output_at = time.time()
             output_parts.append(text)
             line_buffer += text
             while "\n" in line_buffer:
@@ -317,14 +355,31 @@ def main():
                 clean = strip_terminal(line).rstrip()
                 if clean:
                     post_event("log", clean)
-            result = parse_result("".join(output_parts))
-            if result and result.get("story_id"):
-                break
 
         if line_buffer:
             clean = strip_terminal(line_buffer).rstrip()
             if clean:
                 post_event("log", clean)
+
+        exit_code = proc.wait()
+        os.close(master_fd)
+
+        if result_path.exists():
+            try:
+                final_message = result_path.read_text(encoding="utf-8")
+                if final_message:
+                    output_parts.append("\n" + final_message)
+                    result = parse_result(final_message)
+            except Exception as exc:
+                post_event("warning", "Could not read Codex final message: " + str(exc))
+
+        if exit_code != 0:
+            patch_job("failed", error="Codex exited with status " + str(exit_code))
+            post_event("error", "Codex exited with status " + str(exit_code))
+            return exit_code
+
+        if not result:
+            result = parse_result("".join(output_parts))
 
         if result and result.get("story_id"):
             patch_job(
@@ -333,36 +388,12 @@ def main():
                 title=str(result.get("title") or ""),
             )
             post_event("complete", "Story created.", result)
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=10)
-            os.close(master_fd)
             return 0
 
-        exit_code = proc.wait()
-        os.close(master_fd)
-        output = "".join(output_parts)
-        if exit_code != 0:
-            patch_job("failed", error="Codex exited with status " + str(exit_code))
-            post_event("error", "Codex exited with status " + str(exit_code))
-            return exit_code
-
-        result = parse_result(output)
         if not result or not result.get("story_id"):
             patch_job("failed", error="Codex completed without a story_id result marker.")
             post_event("error", "Codex completed without a story_id result marker.")
             return 2
-
-        patch_job(
-            "complete",
-            story_id=int(result["story_id"]),
-            title=str(result.get("title") or ""),
-        )
-        post_event("complete", "Story created.", result)
-        return 0
     finally:
         task_stop.set()
         release_task()

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -743,6 +743,7 @@ describe('Story page', () => {
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('story-agent-');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('STORY_AGENT_TASK_NAME=');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain("printf '%s\\n'");
+                        expect(launchUrl.searchParams.getAll('cmd').join(' ')).toContain('Mozilla/5.0');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('STORY_AGENT_ENV');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('& &&');
                         expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
@@ -919,14 +920,22 @@ describe('Story page', () => {
         });
 
         it('passes Sprite reference image paths into Codex and generate-story', () => {
-                expect(STORY_AGENT_RUNNER).toContain('Reference images are attached to this Codex request');
+                expect(STORY_AGENT_RUNNER).toContain('Reference images are available at the /tmp paths above');
                 expect(STORY_AGENT_RUNNER).toContain('--ref-image');
-                expect(STORY_AGENT_RUNNER).toContain('cmd.extend(["--image", ref_path])');
+                expect(STORY_AGENT_RUNNER).not.toContain('cmd.extend(["--image", ref_path])');
+                expect(STORY_AGENT_RUNNER).not.toContain('STORY_AGENT_RESULT_JSON={');
+                expect(STORY_AGENT_RUNNER).not.toContain('"story_id":123');
                 expect(STORY_AGENT_RUNNER).toContain('output_dir / (str(ref.get("id", len(paths) + 1)) + "-" + safe_name)');
                 expect(STORY_AGENT_RUNNER).toContain('pty.openpty()');
                 expect(STORY_AGENT_RUNNER).toContain('os.write(');
                 expect(STORY_AGENT_RUNNER).not.toContain('stdin=subprocess.DEVNULL');
+                expect(STORY_AGENT_RUNNER).toContain('"exec"');
+                expect(STORY_AGENT_RUNNER).toContain('"--color"');
+                expect(STORY_AGENT_RUNNER).toContain('"--output-last-message"');
+                expect(STORY_AGENT_RUNNER).not.toContain('"--no-alt-screen"');
                 expect(STORY_AGENT_RUNNER).toContain('STORY_AGENT_TASK_NAME');
                 expect(STORY_AGENT_RUNNER).toContain('("story-agent-" + JOB_ID).lower()');
+                expect(STORY_AGENT_RUNNER).toContain('"User-Agent": USER_AGENT');
+                expect(STORY_AGENT_RUNNER).toContain('headers={"Authorization": "Bearer " + JOB_TOKEN, "User-Agent": USER_AGENT}');
         });
 });


### PR DESCRIPTION
## Summary
- Fixes the managed story-agent Sprite workflow so Codex runs non-interactively and waits for real story publishing results before completing jobs.

## Changes
- Switches the Sprite runner from interactive `codex` to `codex exec` with `--output-last-message` and line-streamed status updates.
- Removes direct `--image` arguments to Codex and keeps reference image paths in the prompt, matching the manual workflow while still instructing `generate-story` to use `--ref-image`.
- Prevents placeholder result JSON from being parsed as a real story result and waits for Codex to exit before marking jobs complete.
- Adds browser-like story API user-agent handling for Sprite-side helper scripts to avoid Cloudflare Browser Integrity Check 1010 blocks.
- Documents the story-agent user-agent behavior and adds regression coverage for the runner command and prompt/result parsing guardrails.

## Testing
- `npm test -- --run`
- `npx tsc --noEmit`
- Deployed and verified the Worker runner path manually during debugging.
- Verified the Sprite had no active `story-agent`/`codex` processes or task holds after cleanup.
