### PR TITLE
Move Codex story generation to dedicated page

### DIFF
--- a/public/generate-story.html
+++ b/public/generate-story.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Generate Story with Codex</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; color: #222; background: #f6f7f9; }
+        h1, h2 { margin: 0; }
+        button, input, textarea { font: inherit; }
+        button { cursor: pointer; }
+        button:disabled { cursor: not-allowed; opacity: 0.65; }
+        .page { max-width: 1180px; margin: 0 auto; }
+        .title-row { display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+        .title-link { color: #1f5fbf; text-decoration: none; }
+        .title-link:hover { text-decoration: underline; }
+        .prompt-panel, .jobs-panel, .job-detail { background: #fff; border: 1px solid #ddd; border-radius: 8px; }
+        .prompt-panel { padding: 1rem; margin-bottom: 1rem; }
+        .agent-form { display: grid; gap: 0.75rem; }
+        .agent-form textarea { width: 100%; box-sizing: border-box; min-height: 7rem; resize: vertical; }
+        .agent-row { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+        .agent-row input[type="date"] { min-height: 2rem; }
+        .agent-files { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+        .agent-file { display: inline-flex; align-items: center; gap: 0.25rem; border: 1px solid #ccc; border-radius: 6px; padding: 0.2rem 0.4rem; background: #fff; font-size: 0.85rem; }
+        .agent-file button { border: 0; background: transparent; font-weight: bold; line-height: 1; }
+        .agent-error { color: #b00020; margin-top: 0.5rem; }
+        .workspace { display: grid; grid-template-columns: minmax(230px, 300px) minmax(0, 1fr); gap: 1rem; align-items: start; }
+        .jobs-panel { padding: 0.75rem; }
+        .panel-heading { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+        .panel-heading h2 { font-size: 1rem; }
+        .job-list { display: grid; gap: 0.5rem; }
+        .job-button { width: 100%; text-align: left; border: 1px solid #ddd; border-radius: 6px; background: #fff; padding: 0.55rem; display: grid; gap: 0.25rem; }
+        .job-button:hover, .job-button.selected { border-color: #1f5fbf; background: #f3f7ff; }
+        .job-title { display: flex; align-items: center; gap: 0.4rem; min-width: 0; }
+        .job-prompt { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .job-meta { color: #666; font-size: 0.82rem; }
+        .status-dot { width: 0.65rem; height: 0.65rem; border-radius: 50%; flex: 0 0 auto; background: #777; }
+        .status-starting, .status-queued { background: #8a6d00; }
+        .status-running { background: #0d65c2; }
+        .status-complete { background: #16833a; }
+        .status-failed { background: #b00020; }
+        .status-canceled { background: #777; }
+        .status-badge { display: inline-flex; align-items: center; gap: 0.35rem; color: #444; font-size: 0.9rem; }
+        .job-detail { padding: 1rem; min-width: 0; }
+        .detail-header { display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; margin-bottom: 0.75rem; }
+        .detail-header h2 { font-size: 1.15rem; overflow-wrap: anywhere; }
+        .detail-actions { display: inline-flex; gap: 0.5rem; flex-wrap: wrap; justify-content: flex-end; }
+        .review-link { color: #1f5fbf; }
+        .agent-log { padding: 0.75rem; background: #111; color: #eee; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 0.85rem; line-height: 1.35; min-height: 22rem; max-height: 34rem; overflow: auto; white-space: pre-wrap; }
+        .agent-chat { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+        .agent-chat input { flex: 1; min-width: 0; }
+        .empty-state { padding: 1rem; color: #666; }
+        .page > .empty-state { background: #fff; border: 1px solid #ddd; border-radius: 8px; }
+        @media (max-width: 760px) {
+            .title-row, .detail-header { flex-direction: column; align-items: stretch; }
+            .workspace { grid-template-columns: 1fr; }
+            .agent-row button, .agent-row input { width: 100%; }
+            .agent-chat { flex-direction: column; }
+            .detail-actions { justify-content: flex-start; }
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script>
+        const { useState, useEffect } = React;
+
+        async function agentFetch(url, options) {
+            const res = await fetch(url, options);
+            if (res.redirected && new URL(res.url).pathname === '/login') {
+                window.location.href = '/login';
+                throw new Error('Redirecting to login');
+            }
+            if (res.status === 401) {
+                window.location.href = '/login';
+                throw new Error('Unauthorized');
+            }
+            return res;
+        }
+
+        async function responseErrorMessage(res, fallback) {
+            let text = '';
+            try { text = await res.text(); } catch {}
+            if (/<\s*(!doctype|html|head|body)\b/i.test(text)) {
+                return fallback || `${res.status} ${res.statusText || 'Error'}`;
+            }
+            const normalized = text.replace(/\s+/g, ' ').trim();
+            return normalized
+                ? normalized.slice(0, 600)
+                : fallback || `${res.status} ${res.statusText || 'Error'}`;
+        }
+
+        function displayMessage(value) {
+            const text = String(value || '');
+            if (/<\s*(!doctype|html|head|body)\b/i.test(text)) {
+                return 'Upstream service returned an HTML error page.';
+            }
+            return text.length > 800 ? text.slice(0, 797) + '...' : text;
+        }
+
+        function shortPrompt(value) {
+            if (!value) return '';
+            return value.length > 80 ? value.slice(0, 77) + '...' : value;
+        }
+
+        function imageFilesFromList(list) {
+            return Array.from(list || []).filter(file => file && file.type && file.type.startsWith('image/'));
+        }
+
+        function statusDotClass(status) {
+            return 'status-dot status-' + String(status || '').toLowerCase();
+        }
+
+        function formatJobDate(value) {
+            if (!value) return '';
+            const date = new Date(value);
+            return Number.isNaN(date.getTime()) ? '' : date.toLocaleString();
+        }
+
+        function jobDisplayTitle(job) {
+            if (!job) return 'No job selected';
+            return job.title || shortPrompt(job.prompt) || 'Story generation job';
+        }
+
+        function App() {
+            const [agentPrompt, setAgentPrompt] = useState('');
+            const [agentDate, setAgentDate] = useState('');
+            const [agentFiles, setAgentFiles] = useState([]);
+            const [agentFileInputKey, setAgentFileInputKey] = useState(0);
+            const [agentJobs, setAgentJobs] = useState([]);
+            const [activeJob, setActiveJob] = useState(null);
+            const [agentEvents, setAgentEvents] = useState([]);
+            const [agentMessage, setAgentMessage] = useState('');
+            const [agentBusy, setAgentBusy] = useState(false);
+            const [agentError, setAgentError] = useState('');
+            const [agentUnavailable, setAgentUnavailable] = useState('');
+
+            const loadAgentJobs = async () => {
+                const res = await agentFetch('/agent/jobs');
+                if (res.status === 403 || res.status === 503) {
+                    setAgentUnavailable(await responseErrorMessage(res, 'Codex generation is not available for this account.'));
+                    return;
+                }
+                if (!res.ok) {
+                    setAgentError(await responseErrorMessage(res, 'Could not load generation jobs.'));
+                    return;
+                }
+                const data = await res.json();
+                const jobs = data.jobs || [];
+                setAgentUnavailable('');
+                setAgentJobs(jobs);
+                setActiveJob(current => {
+                    if (!current) return jobs[0] || null;
+                    return jobs.find(job => job.id === current.id) || current;
+                });
+            };
+
+            const refreshAgentJob = async id => {
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(id));
+                if (!res.ok) return;
+                const data = await res.json();
+                setActiveJob(data.job);
+                setAgentJobs(jobs => jobs.map(job => job.id === data.job.id ? data.job : job));
+            };
+
+            useEffect(() => { loadAgentJobs(); }, []);
+
+            useEffect(() => {
+                if (!activeJob) return;
+                setAgentEvents([]);
+                let lastId = 0;
+                let closed = false;
+                let source = null;
+                const connect = () => {
+                    if (closed) return;
+                    const suffix = lastId ? '?after=' + lastId : '';
+                    source = new EventSource('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/events' + suffix);
+                    const onEvent = event => {
+                        if (typeof event.data !== 'string') return;
+                        lastId = Math.max(lastId, Number(event.lastEventId || 0));
+                        let data = {};
+                        try { data = JSON.parse(event.data); } catch { data = { message: event.data }; }
+                        setAgentEvents(events => events.concat([{ id: lastId, type: event.type, message: data.message || '', metadata: data.metadata || null }]).slice(-200));
+                        if (['complete','failed','canceled','running','starting','status'].includes(event.type)) {
+                            refreshAgentJob(activeJob.id);
+                            loadAgentJobs();
+                        }
+                    };
+                    const onConnectionError = event => {
+                        if (typeof event.data === 'string') {
+                            onEvent(event);
+                            return;
+                        }
+                        if (source) source.close();
+                        if (!closed) setTimeout(connect, 2500);
+                    };
+                    ['status','log','feedback','warning','complete','failed','canceled','running','starting'].forEach(type => source.addEventListener(type, onEvent));
+                    source.addEventListener('error', onConnectionError);
+                };
+                connect();
+                return () => {
+                    closed = true;
+                    if (source) source.close();
+                };
+            }, [activeJob && activeJob.id]);
+
+            const addAgentFiles = files => {
+                const images = imageFilesFromList(files);
+                if (images.length === 0) return;
+                setAgentError('');
+                setAgentFiles(current => {
+                    const next = current.concat(images).slice(0, 3);
+                    if (current.length + images.length > 3) {
+                        setAgentError('Only the first 3 reference images will be used.');
+                    }
+                    return next;
+                });
+            };
+
+            const onAgentFileChange = e => {
+                addAgentFiles(e.target.files || []);
+                setAgentFileInputKey(value => value + 1);
+            };
+
+            const onAgentPromptPaste = e => {
+                const pastedFiles = imageFilesFromList(e.clipboardData && e.clipboardData.files);
+                if (pastedFiles.length > 0) {
+                    addAgentFiles(pastedFiles);
+                    if (!e.clipboardData.getData('text')) {
+                        e.preventDefault();
+                    }
+                    return;
+                }
+                const itemFiles = Array.from((e.clipboardData && e.clipboardData.items) || [])
+                    .filter(item => item.kind === 'file' && item.type.startsWith('image/'))
+                    .map(item => item.getAsFile())
+                    .filter(Boolean);
+                if (itemFiles.length > 0) {
+                    addAgentFiles(itemFiles);
+                    if (!e.clipboardData.getData('text')) {
+                        e.preventDefault();
+                    }
+                }
+            };
+
+            const removeAgentFile = index => {
+                setAgentFiles(files => files.filter((_, i) => i !== index));
+            };
+
+            const startAgentJob = async e => {
+                e.preventDefault();
+                setAgentError('');
+                setAgentBusy(true);
+                const fd = new FormData();
+                fd.append('prompt', agentPrompt.trim());
+                if (agentDate) fd.append('date', agentDate);
+                agentFiles.forEach(file => fd.append('ref_images', file, file.name));
+                try {
+                    const res = await agentFetch('/agent/jobs', { method: 'POST', body: fd });
+                    if (!res.ok) {
+                        setAgentError(await responseErrorMessage(res, 'Could not start the generation job.'));
+                        return;
+                    }
+                    const data = await res.json();
+                    setActiveJob(data.job);
+                    setAgentJobs(jobs => [data.job].concat(jobs.filter(job => job.id !== data.job.id)));
+                    setAgentPrompt('');
+                    setAgentDate('');
+                    setAgentFiles([]);
+                    setAgentFileInputKey(value => value + 1);
+                } finally {
+                    setAgentBusy(false);
+                }
+            };
+
+            const selectAgentJob = job => {
+                setAgentError('');
+                setActiveJob(job);
+            };
+
+            const sendAgentMessage = async e => {
+                e.preventDefault();
+                if (!activeJob || !agentMessage.trim()) return;
+                const content = agentMessage.trim();
+                setAgentMessage('');
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/messages', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content })
+                });
+                if (!res.ok) setAgentError(await responseErrorMessage(res, 'Could not send feedback.'));
+            };
+
+            const cancelAgent = async () => {
+                if (!activeJob || !confirm('Cancel this generation job?')) return;
+                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/cancel', { method: 'POST' });
+                if (res.ok) refreshAgentJob(activeJob.id);
+                else setAgentError(await responseErrorMessage(res, 'Could not cancel the job.'));
+            };
+
+            const agentActive = activeJob && !['complete','failed','canceled'].includes(activeJob.status);
+            const logText = agentEvents.length
+                ? agentEvents.map(event => `[${event.type}] ${displayMessage(event.message)}`).join('\n')
+                : 'Waiting for events...';
+
+            return React.createElement('main', { className: 'page' }, [
+                React.createElement('div', { key: 'title', className: 'title-row' }, [
+                    React.createElement('h1', { key: 'h' }, 'Generate Story with Codex'),
+                    React.createElement('a', { key: 'back', href: '/manage', className: 'title-link' }, 'Manage Stories')
+                ]),
+                agentUnavailable ? React.createElement('div', { key: 'unavailable', className: 'empty-state' }, agentUnavailable) : React.createElement(React.Fragment, { key: 'agent' }, [
+                    React.createElement('section', { key: 'prompt', className: 'prompt-panel' }, [
+                        React.createElement('form', { key: 'f', className: 'agent-form', onSubmit: startAgentJob }, [
+                            React.createElement('textarea', { key: 'p', placeholder: 'Story idea', value: agentPrompt, required: true, maxLength: 4000, onPaste: onAgentPromptPaste, onChange: e => setAgentPrompt(e.target.value) }),
+                            React.createElement('div', { key: 'r', className: 'agent-row' }, [
+                                React.createElement('input', { key: 'd', type: 'date', value: agentDate, onChange: e => setAgentDate(e.target.value) }),
+                                React.createElement('input', { key: 'i' + agentFileInputKey, type: 'file', accept: 'image/jpeg,image/png,image/webp', multiple: true, onChange: onAgentFileChange }),
+                                React.createElement('button', { key: 'b', type: 'submit', disabled: agentBusy || !agentPrompt.trim() }, agentBusy ? 'Starting...' : 'Start')
+                            ]),
+                            agentFiles.length ? React.createElement('div', { key: 'files', className: 'agent-files' }, agentFiles.map((file, index) =>
+                                React.createElement('span', { key: file.name + index, className: 'agent-file' }, [
+                                    file.name || 'pasted image',
+                                    React.createElement('button', { key: 'x', type: 'button', onClick: () => removeAgentFile(index), 'aria-label': 'Remove reference image' }, 'x')
+                                ])
+                            )) : null
+                        ]),
+                        agentError ? React.createElement('div', { key: 'err', className: 'agent-error' }, agentError) : null
+                    ]),
+                    React.createElement('div', { key: 'workspace', className: 'workspace' }, [
+                        React.createElement('aside', { key: 'jobs', className: 'jobs-panel' }, [
+                            React.createElement('div', { key: 'head', className: 'panel-heading' }, [
+                                React.createElement('h2', { key: 'h' }, 'Jobs'),
+                                React.createElement('button', { key: 'refresh', type: 'button', onClick: loadAgentJobs }, 'Refresh')
+                            ]),
+                            agentJobs.length ? React.createElement('div', { key: 'list', className: 'job-list' }, agentJobs.map(job =>
+                                React.createElement('button', { key: job.id, type: 'button', className: 'job-button' + (activeJob && activeJob.id === job.id ? ' selected' : ''), onClick: () => selectAgentJob(job) }, [
+                                    React.createElement('span', { key: 'title', className: 'job-title' }, [
+                                        React.createElement('span', { key: 'dot', className: statusDotClass(job.status), 'aria-hidden': 'true' }),
+                                        React.createElement('span', { key: 'prompt', className: 'job-prompt' }, shortPrompt(job.prompt))
+                                    ]),
+                                    React.createElement('span', { key: 'meta', className: 'job-meta' }, [job.status, formatJobDate(job.created)].filter(Boolean).join(' - '))
+                                ])
+                            )) : React.createElement('div', { key: 'empty', className: 'empty-state' }, 'No generation jobs yet.')
+                        ]),
+                        React.createElement('section', { key: 'detail', className: 'job-detail' }, activeJob ? [
+                            React.createElement('div', { key: 'head', className: 'detail-header' }, [
+                                React.createElement('div', { key: 'copy' }, [
+                                    React.createElement('h2', { key: 'h' }, jobDisplayTitle(activeJob)),
+                                    React.createElement('span', { key: 'status', className: 'status-badge' }, [
+                                        React.createElement('span', { key: 'dot', className: statusDotClass(activeJob.status), 'aria-hidden': 'true' }),
+                                        activeJob.status
+                                    ])
+                                ]),
+                                React.createElement('div', { key: 'actions', className: 'detail-actions' }, [
+                                    activeJob.review_url ? React.createElement('a', { key: 'review', className: 'review-link', href: activeJob.review_url, target: '_blank', rel: 'noopener' }, 'Review created story') : null,
+                                    agentActive ? React.createElement('button', { key: 'cancel', type: 'button', onClick: cancelAgent }, 'Cancel') : null
+                                ])
+                            ]),
+                            activeJob.error ? React.createElement('div', { key: 'joberr', className: 'agent-error' }, displayMessage(activeJob.error)) : null,
+                            React.createElement('div', { key: 'log', className: 'agent-log' }, logText),
+                            agentActive ? React.createElement('form', { key: 'chat', className: 'agent-chat', onSubmit: sendAgentMessage }, [
+                                React.createElement('input', { key: 'm', type: 'text', value: agentMessage, maxLength: 2000, placeholder: 'Send feedback', onChange: e => setAgentMessage(e.target.value) }),
+                                React.createElement('button', { key: 'send', type: 'submit', disabled: !agentMessage.trim() }, 'Send')
+                            ]) : null
+                        ] : React.createElement('div', { className: 'empty-state' }, 'Select a generation job.'))
+                    ])
+                ])
+            ]);
+        }
+
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(React.createElement(App));
+    </script>
+</body>
+</html>

--- a/public/manage.html
+++ b/public/manage.html
@@ -7,45 +7,19 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 0; padding: 1rem; line-height: 1.6; }
         h1 { text-align: center; }
+        .actions { display: flex; justify-content: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
         .story-list { max-width: 600px; margin: 1rem auto; }
-        .story-item { display: flex; justify-content: space-between; margin-bottom: 0.5rem; }
+        .story-item { display: flex; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.5rem; }
         .story-item .date { color: #666; margin-left: 0.5rem; font-size: 0.9em; }
+        .story-actions { display: inline-flex; gap: 0.25rem; flex-shrink: 0; }
         .pagination { display: flex; justify-content: center; gap: 0.5rem; margin-top: 1rem; }
-        .search-wrapper { position: relative; max-width: 300px; margin: 0 auto 1rem; }
-        .search-wrapper input[type="text"] { width: 100%; padding-left: 1.5rem; box-sizing: border-box; }
+        .search-wrapper { max-width: 300px; margin: 0 auto 1rem; }
+        .search-wrapper input[type="text"] { width: 100%; box-sizing: border-box; }
         .search-wrapper input[type="date"] { width: 100%; margin-top: 0.25rem; box-sizing: border-box; }
-        /* Position the search icon based on the text input rather than the
-           total wrapper height so it aligns correctly when additional fields
-           are present. */
-        .search-wrapper .icon {
-            position: absolute;
-            left: 0.25rem;
-            top: 0.25rem; /* Align with the text field */
-            line-height: 1;
-            pointer-events: none;
-        }
-        .new-story { text-align: center; margin-bottom: 1rem; }
-        .agent-panel { max-width: 720px; margin: 1rem auto; border: 1px solid #ddd; border-radius: 8px; padding: 1rem; background: #fafafa; }
-        .agent-panel h2 { margin: 0 0 0.75rem; font-size: 1.15rem; }
-        .agent-form { display: grid; gap: 0.5rem; }
-        .agent-form textarea { width: 100%; box-sizing: border-box; font-family: inherit; min-height: 6rem; }
-        .agent-row { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
-        .agent-row input[type="date"] { min-height: 2rem; }
-        .agent-jobs { display: grid; gap: 0.4rem; margin-top: 0.75rem; }
-        .agent-job { display: flex; justify-content: space-between; gap: 0.5rem; align-items: center; padding: 0.5rem; border: 1px solid #ddd; border-radius: 6px; background: white; }
-        .agent-job button { flex-shrink: 0; }
-        .agent-status { font-size: 0.85rem; color: #555; margin-left: 0.4rem; }
-        .agent-log { margin-top: 0.75rem; padding: 0.75rem; background: #111; color: #eee; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 0.85rem; line-height: 1.35; max-height: 18rem; overflow: auto; white-space: pre-wrap; }
-        .agent-chat { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
-        .agent-chat input { flex: 1; min-width: 0; }
-        .agent-files { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-        .agent-file { display: inline-flex; align-items: center; gap: 0.25rem; border: 1px solid #ccc; border-radius: 6px; padding: 0.2rem 0.4rem; background: white; font-size: 0.85rem; }
-        .agent-file button { border: 0; background: transparent; cursor: pointer; font-weight: bold; line-height: 1; }
-        .agent-error { color: #b00020; margin-top: 0.5rem; }
-        .agent-review { display: inline-block; margin-top: 0.5rem; }
         @media (max-width: 560px) {
-            .agent-job, .agent-chat { flex-direction: column; align-items: stretch; }
-            .agent-row button, .agent-row input { width: 100%; }
+            .story-item { flex-direction: column; }
+            .story-actions { display: flex; }
+            .story-actions button { flex: 1; }
         }
     </style>
 </head>
@@ -73,47 +47,19 @@
                 throw err;
             }
         }
-        async function agentFetch(url, options) {
-            const res = await fetch(url, options);
-            if (res.redirected && new URL(res.url).pathname === '/login') {
-                window.location.href = '/login';
-                throw new Error('Redirecting to login');
-            }
-            if (res.status === 401) {
-                window.location.href = '/login';
-                throw new Error('Unauthorized');
-            }
-            return res;
-        }
+
         function toLocalDateString(isoString) {
             const date = new Date(isoString);
             date.setMinutes(date.getMinutes() + date.getTimezoneOffset());
             return date.toLocaleDateString();
         }
-        function shortPrompt(value) {
-            if (!value) return '';
-            return value.length > 80 ? value.slice(0, 77) + '...' : value;
-        }
-        function imageFilesFromList(list) {
-            return Array.from(list || []).filter(file => file && file.type && file.type.startsWith('image/'));
-        }
+
         function App() {
             const [stories, setStories] = useState([]);
             const [page, setPage] = useState(1);
             const [total, setTotal] = useState(0);
             const [q, setQ] = useState('');
             const [date, setDate] = useState('');
-            const [agentAvailable, setAgentAvailable] = useState(true);
-            const [agentPrompt, setAgentPrompt] = useState('');
-            const [agentDate, setAgentDate] = useState('');
-            const [agentFiles, setAgentFiles] = useState([]);
-            const [agentFileInputKey, setAgentFileInputKey] = useState(0);
-            const [agentJobs, setAgentJobs] = useState([]);
-            const [activeJob, setActiveJob] = useState(null);
-            const [agentEvents, setAgentEvents] = useState([]);
-            const [agentMessage, setAgentMessage] = useState('');
-            const [agentBusy, setAgentBusy] = useState(false);
-            const [agentError, setAgentError] = useState('');
 
             const load = (p = page, search = q, d = date) => {
                 const params = new URLSearchParams({ page: String(p) });
@@ -128,68 +74,7 @@
                     });
             };
 
-            const loadAgentJobs = async () => {
-                const res = await agentFetch('/agent/jobs');
-                if (res.status === 403 || res.status === 503) {
-                    setAgentAvailable(false);
-                    return;
-                }
-                if (!res.ok) return;
-                const data = await res.json();
-                setAgentJobs(data.jobs || []);
-                if (!activeJob && data.jobs && data.jobs.length > 0) {
-                    setActiveJob(data.jobs[0]);
-                }
-            };
-
-            const refreshAgentJob = async id => {
-                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(id));
-                if (!res.ok) return;
-                const data = await res.json();
-                setActiveJob(data.job);
-                setAgentJobs(jobs => jobs.map(job => job.id === data.job.id ? data.job : job));
-            };
-
             useEffect(() => load(1, q, date), []);
-            useEffect(() => { loadAgentJobs(); }, []);
-            useEffect(() => {
-                if (!activeJob) return;
-                setAgentEvents([]);
-                let lastId = 0;
-                let closed = false;
-                let source = null;
-                const connect = () => {
-                    if (closed) return;
-                    const suffix = lastId ? '?after=' + lastId : '';
-                    source = new EventSource('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/events' + suffix);
-                    const onEvent = event => {
-                        if (typeof event.data !== 'string') return;
-                        lastId = Math.max(lastId, Number(event.lastEventId || 0));
-                        let data = {};
-                        try { data = JSON.parse(event.data); } catch { data = { message: event.data }; }
-                        setAgentEvents(events => events.concat([{ id: lastId, type: event.type, message: data.message || '', metadata: data.metadata || null }]).slice(-200));
-                        if (['complete','failed','canceled','running','starting'].includes(event.type)) {
-                            refreshAgentJob(activeJob.id);
-                            loadAgentJobs();
-                        }
-                    };
-                    const onConnectionError = event => {
-                        if (typeof event.data === 'string') {
-                            onEvent(event);
-                            return;
-                        }
-                        if (source) source.close();
-                        if (!closed) setTimeout(connect, 2500);
-                    };
-                    ['status','log','feedback','warning','complete','failed','canceled','running','starting'].forEach(type => source.addEventListener(type, onEvent));
-                    source.addEventListener('error', onConnectionError);
-                };
-                connect();
-                return () => {
-                    closed = true;
-                    if (source) source.close();
-                };
-            }, [activeJob && activeJob.id]);
 
             const remove = async id => {
                 if (!confirm('Are You Sure?')) return;
@@ -213,141 +98,15 @@
                 load(1, q, value);
             };
 
-            const addAgentFiles = files => {
-                const images = imageFilesFromList(files);
-                if (images.length === 0) return;
-                setAgentError('');
-                setAgentFiles(current => {
-                    const next = current.concat(images).slice(0, 3);
-                    if (current.length + images.length > 3) {
-                        setAgentError('Only the first 3 reference images will be used.');
-                    }
-                    return next;
-                });
-            };
-
-            const onAgentFileChange = e => {
-                addAgentFiles(e.target.files || []);
-                setAgentFileInputKey(value => value + 1);
-            };
-
-            const onAgentPromptPaste = e => {
-                const pastedFiles = imageFilesFromList(e.clipboardData && e.clipboardData.files);
-                if (pastedFiles.length > 0) {
-                    addAgentFiles(pastedFiles);
-                    if (!e.clipboardData.getData('text')) {
-                        e.preventDefault();
-                    }
-                    return;
-                }
-                const itemFiles = Array.from((e.clipboardData && e.clipboardData.items) || [])
-                    .filter(item => item.kind === 'file' && item.type.startsWith('image/'))
-                    .map(item => item.getAsFile())
-                    .filter(Boolean);
-                if (itemFiles.length > 0) {
-                    addAgentFiles(itemFiles);
-                    if (!e.clipboardData.getData('text')) {
-                        e.preventDefault();
-                    }
-                }
-            };
-
-            const removeAgentFile = index => {
-                setAgentFiles(files => files.filter((_, i) => i !== index));
-            };
-
-            const startAgentJob = async e => {
-                e.preventDefault();
-                setAgentError('');
-                setAgentBusy(true);
-                const fd = new FormData();
-                fd.append('prompt', agentPrompt);
-                if (agentDate) fd.append('date', agentDate);
-                agentFiles.forEach(file => fd.append('ref_images', file, file.name));
-                try {
-                    const res = await agentFetch('/agent/jobs', { method: 'POST', body: fd });
-                    if (!res.ok) {
-                        setAgentError(await res.text());
-                        return;
-                    }
-                    const data = await res.json();
-                    setActiveJob(data.job);
-                    setAgentJobs(jobs => [data.job].concat(jobs.filter(job => job.id !== data.job.id)));
-                    setAgentPrompt('');
-                    setAgentDate('');
-                    setAgentFiles([]);
-                    setAgentFileInputKey(value => value + 1);
-                } finally {
-                    setAgentBusy(false);
-                }
-            };
-
-            const sendAgentMessage = async e => {
-                e.preventDefault();
-                if (!activeJob || !agentMessage.trim()) return;
-                const content = agentMessage.trim();
-                setAgentMessage('');
-                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/messages', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ content })
-                });
-                if (!res.ok) setAgentError(await res.text());
-            };
-
-            const cancelAgent = async () => {
-                if (!activeJob || !confirm('Cancel this generation job?')) return;
-                const res = await agentFetch('/agent/jobs/' + encodeURIComponent(activeJob.id) + '/cancel', { method: 'POST' });
-                if (res.ok) refreshAgentJob(activeJob.id);
-                else setAgentError(await res.text());
-            };
-
             const totalPages = Math.ceil(total / 10) || 1;
-            const agentActive = activeJob && !['complete','failed','canceled'].includes(activeJob.status);
 
             return React.createElement(React.Fragment, null, [
                 React.createElement('h1', { key: 'h' }, 'Manage Stories'),
-                React.createElement('div', { key: 'new', className: 'new-story' },
-                    React.createElement('button', { onClick: () => window.location.href = '/submit' }, 'Submit New Story')
-                ),
-                agentAvailable ? React.createElement('section', { key: 'agent', className: 'agent-panel' }, [
-                    React.createElement('h2', { key: 'h' }, 'Generate with Codex'),
-                    React.createElement('form', { key: 'f', className: 'agent-form', onSubmit: startAgentJob }, [
-                        React.createElement('textarea', { key: 'p', placeholder: 'Story idea', value: agentPrompt, required: true, maxLength: 4000, onPaste: onAgentPromptPaste, onChange: e => setAgentPrompt(e.target.value) }),
-                        React.createElement('div', { key: 'r', className: 'agent-row' }, [
-                            React.createElement('input', { key: 'd', type: 'date', value: agentDate, onChange: e => setAgentDate(e.target.value) }),
-                            React.createElement('input', { key: 'i' + agentFileInputKey, type: 'file', accept: 'image/jpeg,image/png,image/webp', multiple: true, onChange: onAgentFileChange }),
-                            React.createElement('button', { key: 'b', type: 'submit', disabled: agentBusy || !agentPrompt.trim() }, agentBusy ? 'Starting...' : 'Start')
-                        ]),
-                        agentFiles.length ? React.createElement('div', { key: 'files', className: 'agent-files' }, agentFiles.map((file, index) =>
-                            React.createElement('span', { key: file.name + index, className: 'agent-file' }, [
-                                file.name || 'pasted image',
-                                React.createElement('button', { key: 'x', type: 'button', onClick: () => removeAgentFile(index), 'aria-label': 'Remove reference image' }, 'x')
-                            ])
-                        )) : null
-                    ]),
-                    agentError ? React.createElement('div', { key: 'err', className: 'agent-error' }, agentError) : null,
-                    React.createElement('div', { key: 'jobs', className: 'agent-jobs' }, agentJobs.map(job =>
-                        React.createElement('div', { key: job.id, className: 'agent-job' }, [
-                            React.createElement('span', { key: 's' }, [
-                                shortPrompt(job.prompt),
-                                React.createElement('span', { key: 'st', className: 'agent-status' }, job.status)
-                            ]),
-                            React.createElement('button', { key: 'v', type: 'button', onClick: () => setActiveJob(job) }, activeJob && activeJob.id === job.id ? 'Selected' : 'Open')
-                        ])
-                    )),
-                    activeJob ? React.createElement(React.Fragment, { key: 'active' }, [
-                        React.createElement('div', { key: 'log', className: 'agent-log' }, agentEvents.length ? agentEvents.map(event => `[${event.type}] ${event.message}`).join('\n') : 'Waiting for events...'),
-                        activeJob.review_url ? React.createElement('a', { key: 'review', className: 'agent-review', href: activeJob.review_url, target: '_blank', rel: 'noopener' }, 'Review created story') : null,
-                        agentActive ? React.createElement('form', { key: 'chat', className: 'agent-chat', onSubmit: sendAgentMessage }, [
-                            React.createElement('input', { key: 'm', type: 'text', value: agentMessage, maxLength: 2000, placeholder: 'Send feedback', onChange: e => setAgentMessage(e.target.value) }),
-                            React.createElement('button', { key: 'send', type: 'submit', disabled: !agentMessage.trim() }, 'Send'),
-                            React.createElement('button', { key: 'cancel', type: 'button', onClick: cancelAgent }, 'Cancel')
-                        ]) : null
-                    ]) : null
-                ]) : null,
+                React.createElement('div', { key: 'actions', className: 'actions' }, [
+                    React.createElement('button', { key: 'submit', onClick: () => window.location.href = '/submit' }, 'Submit New Story'),
+                    React.createElement('button', { key: 'generate', onClick: () => window.location.href = '/generate-story' }, 'Generate with Codex')
+                ]),
                 React.createElement('div', { key: 'search', className: 'search-wrapper' }, [
-                    React.createElement('span', { key: 'i', className: 'icon' }, '🔍'),
                     React.createElement('input', { key: 's', type: 'text', placeholder: 'Search', value: q, onChange: onSearch }),
                     React.createElement('input', { key: 'd', type: 'date', value: date, onChange: onDateChange })
                 ]),
@@ -357,7 +116,7 @@
                             s.title,
                             React.createElement('span', { key: 'd' + s.id, className: 'date' }, ' (' + toLocalDateString(s.date) + ')')
                         ]),
-                        React.createElement('span', { key: 'a' + s.id }, [
+                        React.createElement('span', { key: 'a' + s.id, className: 'story-actions' }, [
                             React.createElement('button', { key: 'v', onClick: () => window.location.href = '/?id=' + s.id }, 'View'),
                             React.createElement('button', { key: 'e', onClick: () => window.location.href = '/edit.html?id=' + s.id }, 'Edit'),
                             React.createElement('button', { key: 'd', onClick: () => remove(s.id) }, 'Delete')
@@ -371,6 +130,7 @@
                 ])
             ]);
         }
+
         const root = ReactDOM.createRoot(document.getElementById('root'));
         root.render(React.createElement(App));
     </script>

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,6 +19,7 @@ const MAX_AGENT_REF_IMAGE_BYTES = 10 * 1024 * 1024;
 const MAX_AGENT_EVENT_MESSAGE_LENGTH = 8000;
 const MAX_AGENT_ERROR_LENGTH = 2000;
 const MAX_AGENT_TITLE_LENGTH = 200;
+const MAX_SPRITE_ERROR_SNIPPET_BYTES = 500;
 
 const AGENT_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 const JOB_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
@@ -81,6 +82,53 @@ function textResponse(value: string, init?: ResponseInit): Response {
     headers.set('Cache-Control', 'no-store');
     headers.set('Referrer-Policy', 'no-referrer');
     return new Response(value, { ...init, headers });
+}
+
+async function readResponseSnippet(response: Response, maxBytes: number): Promise<string> {
+    if (!response.body) return '';
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+        while (total < maxBytes) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            if (!value) continue;
+            const remaining = maxBytes - total;
+            const chunk = value.byteLength > remaining ? value.slice(0, remaining) : value;
+            chunks.push(chunk);
+            total += chunk.byteLength;
+            if (value.byteLength > remaining) break;
+        }
+    } finally {
+        await reader.cancel().catch(() => undefined);
+    }
+    if (total === 0) return '';
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes).trim();
+}
+
+function cleanUpstreamErrorSnippet(value: string): string {
+    const normalized = value.replace(/\s+/g, ' ').trim();
+    if (!normalized) return '';
+    if (/<\s*(!doctype|html|head|body)\b/i.test(normalized)) return '';
+    return normalized.slice(0, MAX_SPRITE_ERROR_SNIPPET_BYTES);
+}
+
+async function spriteLaunchError(response: Response): Promise<string> {
+    const statusText = response.statusText ? ` ${response.statusText}` : '';
+    const snippet = cleanUpstreamErrorSnippet(
+        await readResponseSnippet(response, MAX_SPRITE_ERROR_SNIPPET_BYTES)
+    );
+    const message = `Sprite launch failed (${response.status}${statusText}).`;
+    return snippet
+        ? `${message} ${snippet}`
+        : `${message} Check SPRITES_API_TOKEN, STORY_AGENT_SPRITE_NAME, and Sprites access.`;
 }
 
 function parseAllowedEmails(env: Env): Set<string> {
@@ -303,11 +351,13 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
 
     const response = await fetch(url.toString(), {
         method: 'POST',
-        headers: { Authorization: `Bearer ${config.token}` }
+        headers: {
+            Authorization: `Bearer ${config.token}`,
+            'User-Agent': SPRITE_RUNNER_USER_AGENT
+        }
     });
     if (!response.ok) {
-        const body = await response.text();
-        throw new Error(`Sprite launch failed (${response.status}): ${body.slice(0, 500)}`);
+        throw new Error(await spriteLaunchError(response));
     }
     await appendAgentEvent(env, jobId, 'status', 'Sprite runner launch command accepted.');
 }
@@ -329,7 +379,10 @@ async function cancelSpriteJob(env: Env, jobId: string) {
     url.searchParams.set('dir', config.workdir);
     await fetch(url.toString(), {
         method: 'POST',
-        headers: { Authorization: `Bearer ${config.token}` }
+        headers: {
+            Authorization: `Bearer ${config.token}`,
+            'User-Agent': SPRITE_RUNNER_USER_AGENT
+        }
     });
 }
 
@@ -416,7 +469,7 @@ export async function createAgentJob(request: Request, env: Env, ctx: ExecutionC
         launchSpriteJob(env, origin, jobId, callbackToken).catch(async error => {
             const message = error instanceof Error ? error.message : 'Sprite launch failed';
             await updateJobStatus(env, jobId, 'failed', { error: message });
-            await appendAgentEvent(env, jobId, 'error', message);
+            await appendAgentEvent(env, jobId, 'failed', message);
         })
     );
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -658,6 +658,18 @@ const routes: Route[] = [
     },
     {
         method: 'GET',
+        pattern: /^\/generate-story(?:\.html|\/)?$/,
+        handler: async (request, env, _ctx, _match, _url, auth) => {
+            if (auth.role !== 'editor') return new Response('Forbidden', { status: 403 });
+            const assetRequest = new Request(request.url.replace(/\/generate-story\/?$/, '/generate-story.html'), request);
+            const res = await env.ASSETS.fetch(assetRequest);
+            const headers = new Headers(res.headers);
+            applyHtmlSecurityHeaders(headers, { cacheNoStore: true });
+            return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+        }
+    },
+    {
+        method: 'GET',
         pattern: /^\/edit(?:\.html|\/)?$/,
         handler: async (request, env, _ctx, _match, _url, auth) => {
             if (auth.role !== 'editor') return new Response('Forbidden', { status: 403 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -482,6 +482,7 @@ describe('Story page', () => {
                 const body = await response.text();
                 expect(body).toContain('Manage Stories');
                 expect(body).toContain('Submit New Story');
+                expect(body).toContain('Generate with Codex');
                 expect(response.headers.get('Cache-Control')).toBe('no-store');
                 expect(response.headers.get('X-Frame-Options')).toBe('DENY');
         });
@@ -492,6 +493,25 @@ describe('Story page', () => {
                 const body = await response.text();
                 expect(body).toContain('Manage Stories');
                 expect(body).toContain('Submit New Story');
+                expect(body).toContain('Generate with Codex');
+        });
+
+        it('serves the Codex generation page', async () => {
+                const jwt = await signSession('test@example.com', env);
+                const response = await workerFetch('https://example.com/generate-story', { headers: { cookie: `session=${jwt}` } });
+                const body = await response.text();
+                expect(body).toContain('Generate Story with Codex');
+                expect(body).toContain('Jobs');
+                expect(response.headers.get('Cache-Control')).toBe('no-store');
+                expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+        });
+
+        it('serves the Codex generation page with trailing slash', async () => {
+                const jwt = await signSession('test@example.com', env);
+                const response = await workerFetch('https://example.com/generate-story/', { headers: { cookie: `session=${jwt}` } });
+                const body = await response.text();
+                expect(body).toContain('Generate Story with Codex');
+                expect(body).toContain('Manage Stories');
         });
 
         it('denies reader accounts access to editor pages', async () => {
@@ -501,6 +521,8 @@ describe('Story page', () => {
                 expect(await getAccountRole('reader@example.com', env)).toBe('reader');
                 const resp = await workerFetch('https://example.com/submit', { headers: { cookie: `session=${jwt}` } });
                 expect(resp.status).toBe(403);
+                const generateResp = await workerFetch('https://example.com/generate-story', { headers: { cookie: `session=${jwt}` } });
+                expect(generateResp.status).toBe(403);
         });
 
         it('hides future stories from default endpoint', async () => {
@@ -530,6 +552,13 @@ describe('Story page', () => {
         it('requires login for submit page even when PUBLIC_VIEW is true', async () => {
                 env.PUBLIC_VIEW = 'true';
                 const response = await workerFetch(new Request('https://example.com/submit', { redirect: 'manual' }));
+                expect(response.status).toBe(302);
+                expect(response.headers.get('Location')).toBe('/login');
+        });
+
+        it('requires login for Codex generation page even when PUBLIC_VIEW is true', async () => {
+                env.PUBLIC_VIEW = 'true';
+                const response = await workerFetch(new Request('https://example.com/generate-story', { redirect: 'manual' }));
                 expect(response.status).toBe(302);
                 expect(response.headers.get('Location')).toBe('/login');
         });
@@ -705,7 +734,10 @@ describe('Story page', () => {
                         const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
                         if (url.startsWith('https://api.sprites.dev/')) {
                                 spriteRequests.push(url);
-                                expect(init?.headers).toEqual({ Authorization: 'Bearer sprites-token' });
+                                expect(init?.headers).toEqual({
+                                        Authorization: 'Bearer sprites-token',
+                                        'User-Agent': expect.stringContaining('Mozilla/5.0')
+                                });
                                 return Response.json({ ok: true });
                         }
                         return originalFetch(input as any, init);
@@ -747,6 +779,54 @@ describe('Story page', () => {
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('STORY_AGENT_ENV');
                         expect(launchUrl.searchParams.getAll('cmd').join(' ')).not.toContain('& &&');
                         expect(agentState.events.some(event => event.message.includes('launch command accepted'))).toBe(true);
+                } finally {
+                        globalThis.fetch = originalFetch;
+                }
+        });
+
+        it('marks jobs failed with a concise message when Sprite launch is forbidden', async () => {
+                const originalFetch = globalThis.fetch;
+                globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+                        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+                        if (url.startsWith('https://api.sprites.dev/')) {
+                                expect(init?.headers).toEqual({
+                                        Authorization: 'Bearer sprites-token',
+                                        'User-Agent': expect.stringContaining('Mozilla/5.0')
+                                });
+                                return new Response('<!doctype html><html><body>Forbidden</body></html>', {
+                                        status: 403,
+                                        statusText: 'Forbidden',
+                                        headers: { 'Content-Type': 'text/html' }
+                                });
+                        }
+                        return originalFetch(input as any, init);
+                }) as any;
+
+                try {
+                        const agentState = createAgentState();
+                        env.DB = createDb(['test@example.com'], [], agentState);
+                        env.IMAGES = createAgentImages().bucket;
+                        env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                        env.SPRITES_API_TOKEN = 'sprites-token';
+                        const jwt = await signSession('test@example.com', env);
+                        const data = new FormData();
+                        data.set('prompt', 'A small comet story');
+
+                        const response = await workerFetch(new Request('https://example.com/agent/jobs', {
+                                method: 'POST',
+                                body: data,
+                                headers: { cookie: `session=${jwt}` }
+                        }));
+
+                        expect(response.status).toBe(202);
+                        expect(agentState.jobs[0].status).toBe('failed');
+                        expect(agentState.jobs[0].error).toContain('Sprite launch failed (403 Forbidden).');
+                        expect(agentState.jobs[0].error).not.toContain('<html>');
+                        expect(agentState.events.some(event =>
+                                event.event_type === 'failed' &&
+                                event.message.includes('Sprite launch failed (403 Forbidden).') &&
+                                !event.message.includes('<html>')
+                        )).toBe(true);
                 } finally {
                         globalThis.fetch = originalFetch;
                 }


### PR DESCRIPTION
## Summary
- Move Codex story generation from `/manage` to a dedicated `/generate-story` page.

## Changes
- Add a standalone generation UI with prompt/reference image input, job status list, live log view, feedback, cancellation, and review links.
- Keep `/manage` focused on story management and add a navigation button to the Codex generation page.
- Add a protected Worker route for `/generate-story` with the same editor-only HTML security behavior as existing editor pages.
- Improve Sprite launch error handling so upstream HTML failures become concise failed-job messages and status updates refresh correctly.

## Testing
- `npm test -- --run`
- `npx tsc --noEmit`
- Parsed inline scripts in `public/manage.html` and `public/generate-story.html` with Node `vm.Script`.
