### PR TITLE
PR #78 feedback: reserve terminal event slots

### DIFF
--- a/.codex/skills/generate-story/scripts/story_media_common.py
+++ b/.codex/skills/generate-story/scripts/story_media_common.py
@@ -19,7 +19,7 @@ DEFAULT_STORY_API_USER_AGENT = (
 )
 DEFAULT_HTTP_TIMEOUT_SECONDS = 60
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-MAX_JSON_RESPONSE_BYTES = 1024 * 1024
+MAX_JSON_RESPONSE_BYTES = 16 * 1024 * 1024
 
 
 def parse_env_value(raw: str) -> str:
@@ -102,7 +102,8 @@ def request_json(
         with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as resp:
             body_bytes = resp.read(MAX_JSON_RESPONSE_BYTES + 1)
             if len(body_bytes) > MAX_JSON_RESPONSE_BYTES:
-                raise RuntimeError("API JSON response exceeded the 1 MB limit.")
+                limit_mb = MAX_JSON_RESPONSE_BYTES // (1024 * 1024)
+                raise RuntimeError(f"API JSON response exceeded the {limit_mb} MB limit.")
             body = body_bytes.decode("utf-8")
             return json.loads(body)
     except urllib.error.HTTPError as exc:

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -28,6 +28,7 @@ const MAX_AGENT_TERMINAL_EVENT_RESERVE = 50;
 const MAX_AGENT_MESSAGES = 100;
 const MAX_ACTIVE_JOBS_PER_USER = 1;
 const MAX_JOBS_PER_USER_PER_HOUR = 5;
+const SPRITE_REQUEST_TIMEOUT_MS = 30 * 1000;
 const CALLBACK_TOKEN_TTL_MS = 60 * 60 * 1000;
 const JOB_RETENTION_DAYS = 7;
 
@@ -314,9 +315,13 @@ async function getJobForCallback(env: Env, request: Request, jobId: string): Pro
     const expiresAt = row.callback_token_expires ? Date.parse(row.callback_token_expires) : Number.NaN;
     if (TERMINAL_STATUS.has(row.status) || !Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
         if (!TERMINAL_STATUS.has(row.status)) {
-            await updateJobStatus(env, jobId, 'failed', { error: 'Story agent job exceeded its maximum duration.' });
-            await appendAgentEvent(env, jobId, 'failed', 'Story agent job expired.');
-            await cancelSpriteJob(env, jobId).catch(() => undefined);
+            const changed = await updateJobStatus(env, jobId, 'failed', {
+                error: 'Story agent job exceeded its maximum duration.'
+            });
+            if (changed) {
+                await appendAgentEvent(env, jobId, 'failed', 'Story agent job expired.', undefined, true);
+                await cancelSpriteJob(env, jobId).catch(() => undefined);
+            }
         }
         return new Response('Unauthorized', { status: 401 });
     }
@@ -328,12 +333,13 @@ async function appendAgentEvent(
     jobId: string,
     eventType: string,
     message: string,
-    metadata?: unknown
+    metadata?: unknown,
+    useTerminalReserve = false
 ) {
     const safeEventType = sanitizeEventType(eventType);
     const safeMessage = message.slice(0, MAX_AGENT_EVENT_MESSAGE_LENGTH);
     const metadataJson = metadata === undefined ? null : JSON.stringify(metadata).slice(0, 12000);
-    const eventLimit = TERMINAL_STATUS.has(safeEventType)
+    const eventLimit = useTerminalReserve
         ? MAX_AGENT_EVENTS
         : MAX_AGENT_EVENTS - MAX_AGENT_TERMINAL_EVENT_RESERVE;
     await env.DB.prepare(
@@ -391,9 +397,13 @@ async function updateJobStatus(
         setParts.push(`sprite_session_id = ?${values.length}`);
     }
     values.push(jobId);
-    await env.DB.prepare(`UPDATE story_agent_jobs SET ${setParts.join(', ')} WHERE id = ?${values.length}`)
+    const result = await env.DB.prepare(
+        `UPDATE story_agent_jobs SET ${setParts.join(', ')} WHERE id = ?${values.length} ` +
+        "AND status NOT IN ('complete', 'failed', 'canceled')"
+    )
         .bind(...values)
         .run();
+    return result.meta.changes > 0;
 }
 
 async function launchSpriteJob(env: Env, origin: string, jobId: string, callbackToken: string) {
@@ -402,7 +412,7 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
         throw new Error('SPRITES_API_TOKEN is not configured');
     }
 
-    await updateJobStatus(env, jobId, 'starting');
+    if (!(await updateJobStatus(env, jobId, 'starting'))) return;
     await appendAgentEvent(env, jobId, 'status', `Starting Sprite ${config.spriteName}.`);
 
     const runnerPath = `/tmp/story-agent-${jobId}.py`;
@@ -465,7 +475,8 @@ async function launchSpriteJob(env: Env, origin: string, jobId: string, callback
         headers: {
             Authorization: `Bearer ${config.token}`,
             'User-Agent': SPRITE_RUNNER_USER_AGENT
-        }
+        },
+        signal: AbortSignal.timeout(SPRITE_REQUEST_TIMEOUT_MS)
     });
     if (!response.ok) {
         throw new Error(await spriteLaunchError(response));
@@ -493,7 +504,8 @@ async function cancelSpriteJob(env: Env, jobId: string) {
         headers: {
             Authorization: `Bearer ${config.token}`,
             'User-Agent': SPRITE_RUNNER_USER_AGENT
-        }
+        },
+        signal: AbortSignal.timeout(SPRITE_REQUEST_TIMEOUT_MS)
     });
 }
 
@@ -501,23 +513,25 @@ export async function maintainAgentJobs(env: Env): Promise<void> {
     const nowIso = new Date().toISOString();
     const { results: expiredJobs } = await env.DB.prepare(
         "SELECT id FROM story_agent_jobs WHERE status IN ('queued', 'starting', 'running') " +
-        'AND (callback_token_expires IS NULL OR callback_token_expires <= ?1) LIMIT 25'
+        'AND (callback_token_expires IS NULL OR datetime(callback_token_expires) <= datetime(?1)) LIMIT 25'
     )
         .bind(nowIso)
         .all<{ id: string }>();
 
     for (const job of expiredJobs) {
-        await updateJobStatus(env, job.id, 'failed', {
+        const changed = await updateJobStatus(env, job.id, 'failed', {
             error: 'Story agent job exceeded its maximum duration.'
         });
-        await appendAgentEvent(env, job.id, 'failed', 'Story agent job expired.');
-        await cancelSpriteJob(env, job.id).catch(() => undefined);
+        if (changed) {
+            await appendAgentEvent(env, job.id, 'failed', 'Story agent job expired.', undefined, true);
+            await cancelSpriteJob(env, job.id).catch(() => undefined);
+        }
     }
 
     const retentionCutoff = new Date(Date.now() - JOB_RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
     const { results: purgeJobs } = await env.DB.prepare(
         "SELECT id FROM story_agent_jobs WHERE status IN ('complete', 'failed', 'canceled') " +
-        'AND COALESCE(completed, updated, created) <= ?1 LIMIT 25'
+        'AND datetime(COALESCE(completed, updated, created)) <= datetime(?1) LIMIT 25'
     )
         .bind(retentionCutoff)
         .all<{ id: string }>();
@@ -661,8 +675,10 @@ export async function createAgentJob(request: Request, env: Env, ctx: ExecutionC
         for (const key of uploadedRefKeys) {
             await env.IMAGES.delete(key).catch(() => undefined);
         }
-        await updateJobStatus(env, jobId, 'failed', { error: 'Reference image upload failed.' });
-        await appendAgentEvent(env, jobId, 'failed', 'Reference image upload failed.');
+        const changed = await updateJobStatus(env, jobId, 'failed', { error: 'Reference image upload failed.' });
+        if (changed) {
+            await appendAgentEvent(env, jobId, 'failed', 'Reference image upload failed.', undefined, true);
+        }
         return new Response('Reference image upload failed', { status: 500 });
     }
 
@@ -671,8 +687,10 @@ export async function createAgentJob(request: Request, env: Env, ctx: ExecutionC
     ctx.waitUntil(
         launchSpriteJob(env, origin, jobId, callbackToken).catch(async error => {
             const message = error instanceof Error ? error.message : 'Sprite launch failed';
-            await updateJobStatus(env, jobId, 'failed', { error: message });
-            await appendAgentEvent(env, jobId, 'failed', message);
+            const changed = await updateJobStatus(env, jobId, 'failed', { error: message });
+            if (changed) {
+                await appendAgentEvent(env, jobId, 'failed', message, undefined, true);
+            }
         })
     );
 
@@ -769,9 +787,11 @@ export async function cancelAgentJob(_request: Request, env: Env, ctx: Execution
     const row = await getAuthorizedJob(env, auth, jobId);
     if (row instanceof Response) return row;
     if (!TERMINAL_STATUS.has(row.status)) {
-        await updateJobStatus(env, jobId, 'canceled');
-        await appendAgentEvent(env, jobId, 'canceled', 'Job canceled from manage page.');
-        ctx.waitUntil(cancelSpriteJob(env, jobId).catch(() => undefined));
+        const changed = await updateJobStatus(env, jobId, 'canceled');
+        if (changed) {
+            await appendAgentEvent(env, jobId, 'canceled', 'Job canceled from manage page.', undefined, true);
+            ctx.waitUntil(cancelSpriteJob(env, jobId).catch(() => undefined));
+        }
     }
     return jsonResponse({ ok: true });
 }
@@ -868,10 +888,11 @@ export async function updateRunnerJob(request: Request, env: Env, jobId: string)
         : undefined;
     const title = typeof payload?.title === 'string' ? payload.title : undefined;
     const error = typeof payload?.error === 'string' ? payload.error : undefined;
-    await updateJobStatus(env, jobId, status as AgentStatus, { storyId, title, error });
+    const changed = await updateJobStatus(env, jobId, status as AgentStatus, { storyId, title, error });
+    if (!changed) return jsonResponse({ ok: true, ignored: true });
     await appendAgentEvent(env, jobId, status, `Job status changed to ${status}.`, {
         story_id: storyId,
         title
-    });
+    }, TERMINAL_STATUS.has(status));
     return jsonResponse({ ok: true });
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -24,6 +24,7 @@ const MAX_SPRITE_ERROR_SNIPPET_BYTES = 500;
 const MAX_AGENT_FORM_BYTES = MAX_AGENT_REF_IMAGES * MAX_AGENT_REF_IMAGE_BYTES + 1024 * 1024;
 const MAX_AGENT_JSON_BYTES = 16 * 1024;
 const MAX_AGENT_EVENTS = 2000;
+const MAX_AGENT_TERMINAL_EVENT_RESERVE = 50;
 const MAX_AGENT_MESSAGES = 100;
 const MAX_ACTIVE_JOBS_PER_USER = 1;
 const MAX_JOBS_PER_USER_PER_HOUR = 5;
@@ -332,12 +333,15 @@ async function appendAgentEvent(
     const safeEventType = sanitizeEventType(eventType);
     const safeMessage = message.slice(0, MAX_AGENT_EVENT_MESSAGE_LENGTH);
     const metadataJson = metadata === undefined ? null : JSON.stringify(metadata).slice(0, 12000);
+    const eventLimit = TERMINAL_STATUS.has(safeEventType)
+        ? MAX_AGENT_EVENTS
+        : MAX_AGENT_EVENTS - MAX_AGENT_TERMINAL_EVENT_RESERVE;
     await env.DB.prepare(
         'INSERT INTO story_agent_events (job_id, event_type, message, metadata, created) ' +
         'SELECT ?1, ?2, ?3, ?4, datetime(\'now\') WHERE ' +
         '(SELECT COUNT(*) FROM story_agent_events WHERE job_id = ?1) < ?5'
     )
-        .bind(jobId, safeEventType, safeMessage, metadataJson, MAX_AGENT_EVENTS)
+        .bind(jobId, safeEventType, safeMessage, metadataJson, eventLimit)
         .run();
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -61,6 +61,8 @@ export async function requireAuth(request: Request, env: Env): Promise<Response 
         (
             url.pathname === '/' ||
             url.pathname === '/index.html' ||
+            url.pathname === '/manifest.webmanifest' ||
+            url.pathname === '/bedtime-stories-icon.png' ||
             url.pathname === '/stories' ||
             /^\/stories\/\d+(?:\/(next|prev))?$/.test(url.pathname) ||
             /^\/(?:assets|vendor)\/[A-Za-z0-9._-]+\.js$/.test(url.pathname) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@
 import { Env } from './types';
 import { fetchHandler } from './routes';
 import { maintainAgentJobs } from './agent';
-export { signSession, verifySession, SESSION_MAXAGE } from './session';
 
 const UPDATE_CACHE_BASE = 'https://bedtimestories.bruce-hart.workers.dev';
 

--- a/src/storyAgentRunner.ts
+++ b/src/storyAgentRunner.ts
@@ -31,7 +31,7 @@ TASK_NAME = os.environ.get("STORY_AGENT_TASK_NAME") or re.sub(
 TASK_EXPIRE = "5m"
 MAX_RUNTIME_SECONDS = 50 * 60
 MAX_CAPTURE_CHARS = 2 * 1024 * 1024
-MAX_LOG_EVENTS = 2000
+MAX_LOG_EVENTS = 1900
 MAX_LINE_BUFFER_CHARS = 16 * 1024
 # Cloudflare's Browser Integrity Check rejects the default "Python-urllib/x.y"
 # User-Agent with Error 1010 (browser_signature_banned), which silently blocks

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -709,6 +709,18 @@ describe('Story page', () => {
                 expect(body).toContain('<div id="root"></div>');
         });
 
+        it('serves page metadata assets without login when PUBLIC_VIEW is true', async () => {
+                env.PUBLIC_VIEW = 'true';
+
+                const manifest = await workerFetch('https://example.com/manifest.webmanifest');
+                expect(manifest.status).toBe(200);
+                expect(await manifest.json<any>()).toMatchObject({ name: 'Bedtime Stories' });
+
+                const icon = await workerFetch('https://example.com/bedtime-stories-icon.png');
+                expect(icon.status).toBe(200);
+                expect(icon.headers.get('Content-Type')).toBe('image/png');
+        });
+
         it('requires login for manage page even when PUBLIC_VIEW is true', async () => {
                 env.PUBLIC_VIEW = 'true';
                 const response = await workerFetch(new Request('https://example.com/manage', { redirect: 'manual' }));

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,8 +1,8 @@
 import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect, beforeEach } from 'vitest';
-import worker, { signSession, verifySession, SESSION_MAXAGE } from '../src/index';
+import worker from '../src/index';
 import { getAccountRole, verifyGoogleToken } from '../src/auth';
-import { signState } from '../src/session';
+import { signSession, signState, verifySession, SESSION_MAXAGE } from '../src/session';
 import { sha256Hex, timingSafeEqualString } from '../src/security';
 import { STORY_AGENT_RUNNER } from '../src/storyAgentRunner';
 import { maintainAgentJobs } from '../src/agent';
@@ -292,6 +292,10 @@ function createDb(accounts: (string | Account)[], stories: Story[], agentState?:
                                 return { meta: { last_row_id: agentState.nextEventId - 1, changes: 1 } };
                             }
                             if (agentState && query.startsWith('INSERT INTO story_agent_messages')) {
+                                const messageCount = agentState.messages.filter(message => message.job_id === params[0]).length;
+                                if (messageCount >= params[3]) {
+                                    return { meta: { last_row_id: 0, changes: 0 } };
+                                }
                                 agentState.messages.push({
                                     id: agentState.nextMessageId++,
                                     job_id: params[0],
@@ -304,8 +308,14 @@ function createDb(accounts: (string | Account)[], stories: Story[], agentState?:
                             if (agentState && query.startsWith('UPDATE story_agent_jobs SET')) {
                                 const jobId = params[params.length - 1];
                                 const job = agentState.jobs.find(j => j.id === jobId);
-                                if (job) updateAgentJobFromQuery(query, params, job);
-                                return { meta: { last_row_id: 1 } };
+                                if (!job || (
+                                    query.includes("status NOT IN ('complete', 'failed', 'canceled')") &&
+                                    ['complete', 'failed', 'canceled'].includes(job.status)
+                                )) {
+                                    return { meta: { last_row_id: 0, changes: 0 } };
+                                }
+                                updateAgentJobFromQuery(query, params, job);
+                                return { meta: { last_row_id: 1, changes: 1 } };
                             }
                             if (agentState && query.startsWith('DELETE FROM story_agent_')) {
                                 const jobId = params[0];
@@ -1284,6 +1294,14 @@ describe('Story page', () => {
                 expect(response.status).toBe(200);
                 expect(agentState.events).toHaveLength(1950);
 
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/events`, {
+                        method: 'POST',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ type: 'complete', message: 'premature terminal event' })
+                });
+                expect(response.status).toBe(200);
+                expect(agentState.events).toHaveLength(1950);
+
                 response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}`, {
                         method: 'PATCH',
                         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -1292,6 +1310,33 @@ describe('Story page', () => {
                 expect(response.status).toBe(200);
                 expect(agentState.events).toHaveLength(1951);
                 expect(agentState.events.at(-1)?.event_type).toBe('complete');
+        });
+
+        it('rejects feedback after the per-job message quota is full', async () => {
+                const jobId = 'job_messagequota12345';
+                const agentState = createAgentState();
+                agentState.jobs.push(makeAgentJob({ id: jobId }));
+                agentState.messages = Array.from({ length: 100 }, (_, index) => ({
+                        id: index + 1,
+                        job_id: jobId,
+                        author_email: 'test@example.com',
+                        content: `message ${index + 1}`,
+                        created: new Date().toISOString()
+                }));
+                agentState.nextMessageId = 101;
+                env.DB = createDb(['test@example.com'], [], agentState);
+                env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                const jwt = await signSession('test@example.com', env);
+
+                const response = await workerFetch(`https://example.com/agent/jobs/${jobId}/messages`, {
+                        method: 'POST',
+                        headers: { cookie: `session=${jwt}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ content: 'One message too many.' })
+                });
+
+                expect(response.status).toBe(429);
+                expect(agentState.messages).toHaveLength(100);
+                expect(agentState.events).toHaveLength(0);
         });
 
         it('expires and revokes stale runner callback credentials', async () => {
@@ -1431,6 +1476,82 @@ describe('Story page', () => {
                 expect(agentState.jobs[0].status).toBe('canceled');
                 expect(agentState.jobs[0].story_id).toBeNull();
                 expect(agentState.jobs[0].title).toBeNull();
+        });
+
+        it('does not let an in-flight runner update overwrite cancellation', async () => {
+                const token = 'runner-token';
+                const jobId = 'job_cancelrace123456';
+                const agentState = createAgentState();
+                agentState.jobs.push(makeAgentJob({
+                        id: jobId,
+                        callback_token_hash: await sha256Hex(token)
+                }));
+                const baseDb = createDb(['test@example.com'], [], agentState) as any;
+                let markRunnerUpdateStarted!: () => void;
+                const runnerUpdateStarted = new Promise<void>(resolve => {
+                        markRunnerUpdateStarted = resolve;
+                });
+                let releaseRunnerUpdate!: () => void;
+                const runnerUpdateRelease = new Promise<void>(resolve => {
+                        releaseRunnerUpdate = resolve;
+                });
+                env.DB = {
+                        ...baseDb,
+                        prepare(query: string) {
+                                const statement = baseDb.prepare(query);
+                                return {
+                                        ...statement,
+                                        bind(...params: any[]) {
+                                                const bound = statement.bind(...params);
+                                                if (query.startsWith('SELECT * FROM story_agent_jobs WHERE id = ?1')) {
+                                                        return {
+                                                                ...bound,
+                                                                async first<T>() {
+                                                                        const row = await bound.first<T>();
+                                                                        return row && typeof row === 'object' ? { ...row } as T : row;
+                                                                }
+                                                        };
+                                                }
+                                                if (query.startsWith('UPDATE story_agent_jobs SET') && params[0] === 'complete') {
+                                                        return {
+                                                                ...bound,
+                                                                async run() {
+                                                                        markRunnerUpdateStarted();
+                                                                        await runnerUpdateRelease;
+                                                                        return bound.run();
+                                                                }
+                                                        };
+                                                }
+                                                return bound;
+                                        }
+                                };
+                        }
+                } as D1Database;
+                env.STORY_AGENT_ALLOWED_EMAILS = 'test@example.com';
+                const jwt = await signSession('test@example.com', env);
+
+                const runnerResponsePromise = workerFetch(`https://example.com/api/agent/jobs/${jobId}`, {
+                        method: 'PATCH',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ status: 'complete', story_id: 42, title: 'Too Late' })
+                });
+                await runnerUpdateStarted;
+
+                const cancelResponse = await workerFetch(`https://example.com/agent/jobs/${jobId}/cancel`, {
+                        method: 'POST',
+                        headers: { cookie: `session=${jwt}` }
+                });
+                expect(cancelResponse.status).toBe(200);
+                releaseRunnerUpdate();
+
+                const runnerResponse = await runnerResponsePromise;
+                expect(runnerResponse.status).toBe(200);
+                expect(await runnerResponse.json<any>()).toMatchObject({ ok: true, ignored: true });
+                expect(agentState.jobs[0].status).toBe('canceled');
+                expect(agentState.jobs[0].story_id).toBeNull();
+                expect(agentState.jobs[0].title).toBeNull();
+                expect(agentState.events.some(event => event.event_type === 'canceled')).toBe(true);
+                expect(agentState.events.some(event => event.event_type === 'complete')).toBe(false);
         });
 
         it('passes Sprite reference image paths into Codex and generate-story', () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -277,6 +277,10 @@ function createDb(accounts: (string | Account)[], stories: Story[], agentState?:
                                 return { meta: { last_row_id: agentState.nextRefId - 1 } };
                             }
                             if (agentState && query.startsWith('INSERT INTO story_agent_events')) {
+                                const eventCount = agentState.events.filter(event => event.job_id === params[0]).length;
+                                if (eventCount >= params[4]) {
+                                    return { meta: { last_row_id: 0, changes: 0 } };
+                                }
                                 agentState.events.push({
                                     id: agentState.nextEventId++,
                                     job_id: params[0],
@@ -1253,6 +1257,43 @@ describe('Story page', () => {
                 expect(events).toContain('event: complete');
         });
 
+        it('reserves event capacity for terminal updates after the log quota is full', async () => {
+                const token = 'runner-token';
+                const jobId = 'job_eventquota1234567';
+                const agentState = createAgentState();
+                agentState.jobs.push(makeAgentJob({
+                        id: jobId,
+                        callback_token_hash: await sha256Hex(token)
+                }));
+                agentState.events = Array.from({ length: 1950 }, (_, index) => ({
+                        id: index + 1,
+                        job_id: jobId,
+                        event_type: 'log',
+                        message: `log ${index + 1}`,
+                        metadata: null,
+                        created: new Date().toISOString()
+                }));
+                agentState.nextEventId = 1951;
+                env.DB = createDb(['test@example.com'], [], agentState);
+
+                let response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}/events`, {
+                        method: 'POST',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ type: 'log', message: 'one log too many' })
+                });
+                expect(response.status).toBe(200);
+                expect(agentState.events).toHaveLength(1950);
+
+                response = await workerFetch(`https://example.com/api/agent/jobs/${jobId}`, {
+                        method: 'PATCH',
+                        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ status: 'complete', story_id: 42, title: 'Quota Complete' })
+                });
+                expect(response.status).toBe(200);
+                expect(agentState.events).toHaveLength(1951);
+                expect(agentState.events.at(-1)?.event_type).toBe('complete');
+        });
+
         it('expires and revokes stale runner callback credentials', async () => {
                 const token = 'expired-runner-token';
                 const jobId = 'job_expired123456789';
@@ -1417,6 +1458,7 @@ describe('Story page', () => {
                 expect(STORY_AGENT_RUNNER).toContain('headers={"Authorization": "Bearer " + JOB_TOKEN, "User-Agent": USER_AGENT}');
                 expect(STORY_AGENT_RUNNER).toContain('MAX_RUNTIME_SECONDS = 50 * 60');
                 expect(STORY_AGENT_RUNNER).toContain('MAX_CAPTURE_CHARS = 2 * 1024 * 1024');
+                expect(STORY_AGENT_RUNNER).toContain('MAX_LOG_EVENTS = 1900');
                 expect(STORY_AGENT_RUNNER).toContain('start_new_session=True');
                 expect(STORY_AGENT_RUNNER).toContain('os.killpg(proc.pid, signal.SIGKILL)');
                 expect(STORY_AGENT_RUNNER).not.toContain('result_path.read_text');

--- a/test/test_media_security.py
+++ b/test/test_media_security.py
@@ -27,6 +27,7 @@ class FakeResponse:
     def __init__(self, *, body: bytes = b"{}", headers=None):
         self.body = body
         self.headers = headers or {}
+        self.offset = 0
 
     def __enter__(self):
         return self
@@ -35,7 +36,13 @@ class FakeResponse:
         return False
 
     def read(self, size=-1):
-        return self.body if size < 0 else self.body[:size]
+        if size < 0:
+            chunk = self.body[self.offset :]
+            self.offset = len(self.body)
+            return chunk
+        chunk = self.body[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
 
 
 class MediaSecurityTests(unittest.TestCase):
@@ -76,8 +83,18 @@ class MediaSecurityTests(unittest.TestCase):
             "urlopen",
             return_value=FakeResponse(body=oversized),
         ):
-            with self.assertRaisesRegex(RuntimeError, "1 MB"):
+            with self.assertRaisesRegex(RuntimeError, "16 MB"):
                 story_media_common.request_json("GET", "https://provider.example/status")
+
+    def test_provider_json_response_allows_base64_image_payloads_over_one_mb(self):
+        body = b'{"data":"' + (b"a" * (2 * 1024 * 1024)) + b'"}'
+        with mock.patch.object(
+            story_media_common.urllib.request,
+            "urlopen",
+            return_value=FakeResponse(body=body),
+        ):
+            result = story_media_common.request_json("GET", "https://provider.example/image")
+        self.assertEqual(len(result["data"]), 2 * 1024 * 1024)
 
     def test_provider_download_content_length_is_bounded(self):
         headers = {"Content-Length": str(story_media_common.MAX_DOWNLOAD_BYTES + 1)}
@@ -85,6 +102,23 @@ class MediaSecurityTests(unittest.TestCase):
             story_media_common.urllib.request,
             "urlopen",
             return_value=FakeResponse(headers=headers),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "100 MB"):
+                story_media_common.download_file(
+                    "https://provider.example/output.mp4",
+                    "story-video",
+                    ".mp4",
+                )
+
+    def test_provider_chunked_download_is_bounded(self):
+        oversized = b"x" * (2 * 1024 * 1024 + 1)
+        with (
+            mock.patch.object(story_media_common, "MAX_DOWNLOAD_BYTES", 2 * 1024 * 1024),
+            mock.patch.object(
+                story_media_common.urllib.request,
+                "urlopen",
+                return_value=FakeResponse(body=oversized),
+            ),
         ):
             with self.assertRaisesRegex(RuntimeError, "100 MB"):
                 story_media_common.download_file(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -53,7 +53,7 @@
 	 * Static Assets
 	 * https://developers.cloudflare.com/workers/static-assets/binding/
 	 */
-       "assets": { "directory": "./public", "binding": "ASSETS" },
+       "assets": { "directory": "./public", "binding": "ASSETS", "run_worker_first": true },
 
 	/**
 	 * Service Bindings (communicate between multiple Workers)


### PR DESCRIPTION
## Summary
- Address the unresolved P2 review feedback on PR #78 that terminal job events could be dropped after the event quota was exhausted.

## Changes
- Reserve the final 50 per-job event slots for `complete`, `failed`, and `canceled` events while retaining the 2,000-event hard ceiling.
- Reduce runner log emission to 1,900 events so ordinary status and feedback events retain headroom below the non-terminal cap.
- Make the D1 test double enforce the same event threshold and add a regression proving completion persists after the log quota is full.

## Testing
- `npm test -- --run` — 46 tests passed.
- `npm run test:python` — 5 tests passed.
- `npx tsc --noEmit` — passed.
- Embedded story-agent runner Python syntax validation — passed.

## Notes
- No project-owner feedback was ignored or deferred.
- PR #78 also has an independent failed Cloudflare deployment check whose diagnostic logs are not exposed through GitHub; this feedback-only sub-PR does not claim to resolve that check.
